### PR TITLE
feat: add FAQ section, handover routes, and onboarding checklist

### DIFF
--- a/apps/api/src/__tests__/integration/handover-routes.test.ts
+++ b/apps/api/src/__tests__/integration/handover-routes.test.ts
@@ -1,0 +1,182 @@
+import request from "supertest";
+import app, { appInit } from "../../app";
+import { getDatabaseClient } from "@handoverkey/database";
+import { SessionService } from "../../services/session-service";
+import { HandoverOrchestrator } from "../../services/handover-orchestrator";
+import { initializeRedis, closeRedis } from "../../config/redis";
+import { registerVerifyLogin, type TestUser } from "../helpers";
+
+jest.setTimeout(60000);
+
+let owner: TestUser;
+
+describe("Handover Routes Integration", () => {
+  beforeAll(async () => {
+    const dbClient = getDatabaseClient();
+    await dbClient.initialize({
+      host: process.env.DB_HOST || "localhost",
+      port: parseInt(process.env.DB_PORT || "5432"),
+      database: "handoverkey_test",
+      user: process.env.DB_USER || "postgres",
+      password: process.env.DB_PASSWORD || "postgres",
+      min: 2,
+      max: 10,
+    });
+    SessionService.initialize(dbClient);
+    await initializeRedis();
+    await appInit;
+
+    owner = await registerVerifyLogin("handover-routes");
+  });
+
+  afterAll(async () => {
+    await closeRedis();
+    await getDatabaseClient().close();
+  });
+
+  describe("GET /api/v1/handover/status", () => {
+    it("should return 401 without authentication", async () => {
+      const res = await request(app).get("/api/v1/handover/status");
+      expect(res.status).toBe(401);
+    });
+
+    it("should return active: false when no handover is active", async () => {
+      const res = await request(app)
+        .get("/api/v1/handover/status")
+        .set("Authorization", `Bearer ${owner.token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.active).toBe(false);
+      expect(res.body.handover).toBeNull();
+    });
+
+    it("should return active handover details when one exists", async () => {
+      const user = await registerVerifyLogin("handover-status-active");
+      const orchestrator = new HandoverOrchestrator();
+      await orchestrator.initiateHandover(user.userId);
+
+      const res = await request(app)
+        .get("/api/v1/handover/status")
+        .set("Authorization", `Bearer ${user.token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.active).toBe(true);
+      expect(res.body.handover).toHaveProperty("id");
+      expect(res.body.handover).toHaveProperty("status");
+      expect(res.body.handover).toHaveProperty("initiatedAt");
+    });
+  });
+
+  describe("POST /api/v1/handover/cancel", () => {
+    it("should return 401 without authentication", async () => {
+      const res = await request(app).post("/api/v1/handover/cancel");
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 404 when no active handover exists", async () => {
+      const res = await request(app)
+        .post("/api/v1/handover/cancel")
+        .set("Authorization", `Bearer ${owner.token}`)
+        .send({});
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should cancel an active handover", async () => {
+      const user = await registerVerifyLogin("handover-cancel");
+      const orchestrator = new HandoverOrchestrator();
+      await orchestrator.initiateHandover(user.userId);
+
+      const res = await request(app)
+        .post("/api/v1/handover/cancel")
+        .set("Authorization", `Bearer ${user.token}`)
+        .send({ reason: "Changed my mind" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toMatch(/cancelled/i);
+
+      const statusRes = await request(app)
+        .get("/api/v1/handover/status")
+        .set("Authorization", `Bearer ${user.token}`);
+      expect(statusRes.body.active).toBe(false);
+    });
+  });
+
+  describe("POST /api/v1/handover/respond", () => {
+    it("should return 400 with missing fields", async () => {
+      const res = await request(app).post("/api/v1/handover/respond").send({});
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 401 with an invalid token", async () => {
+      const res = await request(app)
+        .post("/api/v1/handover/respond")
+        .send({ token: "invalid-token-value", accepted: true });
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should accept a handover via valid successor token", async () => {
+      const user = await registerVerifyLogin("handover-respond");
+      const auth = { Authorization: `Bearer ${user.token}` };
+
+      const s1 = await request(app).post("/api/v1/successors").set(auth).send({
+        email: "respond-succ-1@example.com",
+        name: "Respond Successor 1",
+        handoverDelayDays: 7,
+        encryptedShare: "share-1",
+      });
+      const s2 = await request(app).post("/api/v1/successors").set(auth).send({
+        email: "respond-succ-2@example.com",
+        name: "Respond Successor 2",
+        handoverDelayDays: 7,
+        encryptedShare: "share-2",
+      });
+
+      expect(s1.status).toBe(201);
+      expect(s2.status).toBe(201);
+
+      const orchestrator = new HandoverOrchestrator();
+      const handover = await orchestrator.initiateHandover(user.userId);
+      await orchestrator.processGracePeriodExpiration(handover.id);
+
+      const db = getDatabaseClient().getKysely();
+
+      const successor = await db
+        .selectFrom("successors")
+        .select("verification_token")
+        .where("user_id", "=", user.userId)
+        .executeTakeFirstOrThrow();
+
+      const deadline = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      const successorRows = await db
+        .selectFrom("successors")
+        .select("id")
+        .where("user_id", "=", user.userId)
+        .execute();
+
+      await db
+        .insertInto("successor_notifications")
+        .values(
+          successorRows.map((s) => ({
+            handover_process_id: handover.id,
+            successor_id: s.id,
+            response_deadline: deadline,
+            verification_token: null,
+          })),
+        )
+        .execute();
+
+      const res = await request(app).post("/api/v1/handover/respond").send({
+        token: successor.verification_token,
+        accepted: true,
+        message: "I accept",
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toMatch(/accepted/i);
+      expect(res.body.handoverId).toBe(handover.id);
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/handover-routes.test.ts
+++ b/apps/api/src/__tests__/integration/handover-routes.test.ts
@@ -69,7 +69,7 @@ describe("Handover Routes Integration", () => {
 
   describe("POST /api/v1/handover/cancel", () => {
     it("should return 401 without authentication", async () => {
-      const res = await request(app).post("/api/v1/handover/cancel");
+      const res = await request(app).post("/api/v1/handover/cancel").send({});
       expect(res.status).toBe(401);
     });
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -32,6 +32,7 @@ import activityRoutes, { publicActivityRouter } from "./routes/activity-routes";
 import inactivityRoutes from "./routes/inactivity-routes";
 import sessionRoutes from "./routes/session-routes";
 import successorRoutes, { verifyRouter } from "./routes/successor-routes";
+import handoverRoutes, { publicHandoverRouter } from "./routes/handover-routes";
 import adminRoutes from "./routes/admin-routes";
 import contactRoutes from "./routes/contact-routes";
 import { JobProcessor, JobScheduler } from "./jobs";
@@ -237,6 +238,8 @@ app.use("/api/v1/inactivity", inactivityRoutes);
 app.use("/api/v1/sessions", sessionRoutes);
 app.use("/api/v1/successors", verifyRouter); // Public verify route (no auth)
 app.use("/api/v1/successors", successorRoutes); // Protected routes
+app.use("/api/v1/handover", publicHandoverRouter); // Public respond route
+app.use("/api/v1/handover", handoverRoutes); // Protected routes
 app.use("/api/v1/admin", adminRoutes);
 app.use("/api/v1/contact", contactRoutes);
 

--- a/apps/api/src/controllers/handover-controller.ts
+++ b/apps/api/src/controllers/handover-controller.ts
@@ -1,0 +1,120 @@
+import { Request, Response, NextFunction } from "express";
+import { HandoverOrchestrator } from "../services/handover-orchestrator";
+import { HandoverService } from "../services/handover-service";
+import { SuccessorService } from "../services/successor-service";
+import { UserService } from "../services/user-service";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { AuthenticationError, NotFoundError } from "../errors";
+
+export class HandoverController {
+  static async getStatus(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (!req.user) {
+        throw new AuthenticationError("Not authenticated");
+      }
+
+      const handover = await HandoverService.getActiveHandover(req.user.userId);
+
+      if (!handover) {
+        res.json({ active: false, handover: null });
+        return;
+      }
+
+      res.json({
+        active: true,
+        handover: {
+          id: handover.id,
+          status: handover.status,
+          initiatedAt: handover.initiatedAt,
+          gracePeriodEnds: handover.gracePeriodEnds,
+          completedAt: handover.completedAt,
+          createdAt: handover.createdAt,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async cancel(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (!req.user) {
+        throw new AuthenticationError("Not authenticated");
+      }
+
+      const reason = req.body.reason || "Cancelled by user";
+      const cancelled = await HandoverService.cancelHandover(req.user.userId);
+
+      if (!cancelled) {
+        throw new NotFoundError("Active handover process");
+      }
+
+      await UserService.logActivity(
+        req.user.userId,
+        "HANDOVER_CANCELLED",
+        req.ip,
+      );
+
+      res.json({ message: "Handover process cancelled", reason });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * Public endpoint for successors to accept or decline a handover.
+   * Identified by verification token, not by authentication.
+   */
+  static async respond(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const { token, accepted, message } = req.body;
+
+      const result = await SuccessorService.verifySuccessorByToken(token);
+
+      if (!result.success || !result.userId || !result.successorId) {
+        throw new AuthenticationError("Invalid or expired verification token");
+      }
+
+      const orchestrator = new HandoverOrchestrator();
+      const handover = await orchestrator.getHandoverStatus(result.userId);
+
+      if (!handover) {
+        throw new NotFoundError("Active handover process");
+      }
+
+      await orchestrator.processSuccessorResponse(
+        handover.id,
+        result.successorId,
+        { accepted, message },
+      );
+
+      await UserService.logActivity(
+        result.userId,
+        accepted ? "SUCCESSOR_ACCEPTED" : "SUCCESSOR_DECLINED",
+        req.ip,
+      );
+
+      res.json({
+        message: accepted
+          ? "Handover accepted successfully"
+          : "Handover declined",
+        handoverId: handover.id,
+        status: handover.status,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/api/src/controllers/handover-controller.ts
+++ b/apps/api/src/controllers/handover-controller.ts
@@ -100,6 +100,10 @@ export class HandoverController {
         { accepted, message },
       );
 
+      const updatedHandover = await orchestrator.getHandoverStatus(
+        result.userId,
+      );
+
       await UserService.logActivity(
         result.userId,
         accepted ? "SUCCESSOR_ACCEPTED" : "SUCCESSOR_DECLINED",
@@ -111,7 +115,7 @@ export class HandoverController {
           ? "Handover accepted successfully"
           : "Handover declined",
         handoverId: handover.id,
-        status: handover.status,
+        status: updatedHandover?.status ?? handover.status,
       });
     } catch (error) {
       next(error);

--- a/apps/api/src/routes/handover-routes.ts
+++ b/apps/api/src/routes/handover-routes.ts
@@ -1,0 +1,57 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import { HandoverController } from "../controllers/handover-controller";
+import { authenticateJWT, requireAuth } from "../middleware/auth";
+import { validateRequest } from "../validation";
+import {
+  HandoverRespondSchema,
+  HandoverCancelSchema,
+} from "../validation/schemas";
+
+const router = Router();
+
+router.use(authenticateJWT);
+router.use(requireAuth);
+
+/**
+ * Get current handover status for the authenticated user
+ * GET /api/v1/handover/status
+ */
+router.get("/status", HandoverController.getStatus);
+
+/**
+ * Cancel the active handover process
+ * POST /api/v1/handover/cancel
+ */
+router.post(
+  "/cancel",
+  validateRequest(HandoverCancelSchema, "body"),
+  HandoverController.cancel,
+);
+
+/**
+ * Public endpoint for successors to accept or decline a handover.
+ * Rate limited to prevent abuse.
+ */
+const publicHandoverRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const publicHandoverRouter = Router();
+publicHandoverRouter.use(publicHandoverRateLimiter);
+
+/**
+ * Successor responds to handover (accept/decline)
+ * POST /api/v1/handover/respond
+ */
+publicHandoverRouter.post(
+  "/respond",
+  validateRequest(HandoverRespondSchema, "body"),
+  HandoverController.respond,
+);
+
+export { publicHandoverRouter };
+export default router;

--- a/apps/api/src/validation/schemas/handover.schemas.ts
+++ b/apps/api/src/validation/schemas/handover.schemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const HandoverRespondSchema = z.object({
+  token: z.string().min(1, "Verification token is required"),
+  accepted: z.boolean(),
+  message: z.string().max(500).optional(),
+});
+
+export const HandoverCancelSchema = z.object({
+  reason: z.string().max(500).optional(),
+});

--- a/apps/api/src/validation/schemas/index.ts
+++ b/apps/api/src/validation/schemas/index.ts
@@ -51,5 +51,11 @@ export {
   CheckInTokenSchema,
 } from "./activity.schemas";
 
+// Handover schemas
+export {
+  HandoverRespondSchema,
+  HandoverCancelSchema,
+} from "./handover.schemas";
+
 // Contact schemas
 export { ContactFormSchema } from "./contact.schemas";

--- a/apps/web/src/__tests__/integration/App.test.tsx
+++ b/apps/web/src/__tests__/integration/App.test.tsx
@@ -25,6 +25,8 @@ vi.mock("@heroicons/react/24/outline", () => ({
   CheckCircleIcon: () => <div data-testid="check-icon" />,
   XCircleIcon: () => <div data-testid="error-icon" />,
   InformationCircleIcon: () => <div data-testid="info-icon" />,
+  ChevronDownIcon: () => <div data-testid="chevron-down-icon" />,
+  LockOpenIcon: () => <div data-testid="lock-open-icon" />,
 }));
 
 // Mock the API

--- a/apps/web/src/__tests__/integration/authFlow.int.test.tsx
+++ b/apps/web/src/__tests__/integration/authFlow.int.test.tsx
@@ -32,6 +32,8 @@ vi.mock("@heroicons/react/24/outline", () => ({
   CheckCircleIcon: () => <div data-testid="check-icon" />,
   XCircleIcon: () => <div data-testid="error-icon" />,
   InformationCircleIcon: () => <div data-testid="info-icon" />,
+  ChevronDownIcon: () => <div data-testid="chevron-down-icon" />,
+  LockOpenIcon: () => <div data-testid="lock-open-icon" />,
 }));
 
 // Mock framer-motion

--- a/apps/web/src/__tests__/integration/vaultFlow.int.test.tsx
+++ b/apps/web/src/__tests__/integration/vaultFlow.int.test.tsx
@@ -30,6 +30,8 @@ vi.mock("@heroicons/react/24/outline", () => ({
   CheckCircleIcon: () => <div data-testid="check-icon" />,
   XCircleIcon: () => <div data-testid="error-icon" />,
   InformationCircleIcon: () => <div data-testid="info-icon" />,
+  ChevronDownIcon: () => <div data-testid="chevron-down-icon" />,
+  LockOpenIcon: () => <div data-testid="lock-open-icon" />,
 }));
 
 // Mock framer-motion — strip non-DOM props to silence React warnings

--- a/apps/web/src/components/OnboardingChecklist.tsx
+++ b/apps/web/src/components/OnboardingChecklist.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  CheckCircleIcon,
+  LockClosedIcon,
+  UserGroupIcon,
+  KeyIcon,
+  ClockIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { CheckCircleIcon as CheckCircleSolidIcon } from "@heroicons/react/24/solid";
+
+export interface SetupStatus {
+  hasSecrets: boolean;
+  hasSuccessors: boolean;
+  hasKeyShares: boolean;
+  hasInactivityConfig: boolean;
+}
+
+interface OnboardingChecklistProps {
+  status: SetupStatus;
+  onDismiss: () => void;
+}
+
+const steps = [
+  {
+    key: "hasSecrets" as const,
+    title: "Add your first secret",
+    description: "Store a password, document, or note in your encrypted vault.",
+    href: "/vault",
+    cta: "Go to Vault",
+    icon: LockClosedIcon,
+  },
+  {
+    key: "hasSuccessors" as const,
+    title: "Designate a successor",
+    description:
+      "Add at least one trusted person who will receive your vault data.",
+    href: "/successors",
+    cta: "Add Successor",
+    icon: UserGroupIcon,
+  },
+  {
+    key: "hasKeyShares" as const,
+    title: "Generate key shares",
+    description:
+      "Split your encryption key among successors using Shamir's Secret Sharing.",
+    href: "/successors",
+    cta: "Generate Shares",
+    icon: KeyIcon,
+  },
+  {
+    key: "hasInactivityConfig" as const,
+    title: "Configure your Dead Man's Switch",
+    description:
+      "Set your check-in interval and grace period in inactivity settings.",
+    href: "/settings",
+    cta: "Open Settings",
+    icon: ClockIcon,
+  },
+];
+
+const OnboardingChecklist: React.FC<OnboardingChecklistProps> = ({
+  status,
+  onDismiss,
+}) => {
+  const completedCount = steps.filter((step) => status[step.key]).length;
+  const allComplete = completedCount === steps.length;
+
+  if (allComplete) {
+    return null;
+  }
+
+  const progressPercent = (completedCount / steps.length) * 100;
+
+  return (
+    <div className="card overflow-hidden">
+      <div className="bg-gradient-to-r from-blue-600 to-blue-700 px-6 py-5 flex items-start justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">
+            Set up your legacy plan
+          </h3>
+          <p className="text-blue-100 text-sm mt-1">
+            Complete these steps to fully protect your digital legacy.
+          </p>
+        </div>
+        <button
+          onClick={onDismiss}
+          className="text-blue-200 hover:text-white transition-colors p-1 -mr-1 -mt-1"
+          aria-label="Dismiss checklist"
+        >
+          <XMarkIcon className="w-5 h-5" />
+        </button>
+      </div>
+
+      <div className="px-6 pt-4 pb-2">
+        <div className="flex items-center justify-between text-sm mb-2">
+          <span className="text-gray-600 font-medium">
+            {completedCount} of {steps.length} complete
+          </span>
+          <span className="text-gray-500">{Math.round(progressPercent)}%</span>
+        </div>
+        <div className="w-full bg-gray-100 rounded-full h-2">
+          <div
+            className="bg-blue-600 h-2 rounded-full transition-all duration-500"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </div>
+
+      <ul className="divide-y divide-gray-100 px-6">
+        {steps.map((step) => {
+          const done = status[step.key];
+          return (
+            <li key={step.key} className="flex items-start gap-4 py-4">
+              <div className="mt-0.5 flex-shrink-0">
+                {done ? (
+                  <CheckCircleSolidIcon className="w-6 h-6 text-green-500" />
+                ) : (
+                  <CheckCircleIcon className="w-6 h-6 text-gray-300" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p
+                  className={`text-sm font-semibold ${done ? "text-gray-400 line-through" : "text-gray-900"}`}
+                >
+                  {step.title}
+                </p>
+                <p className="text-sm text-gray-500 mt-0.5">
+                  {step.description}
+                </p>
+              </div>
+              {!done && (
+                <Link
+                  to={step.href}
+                  className="flex-shrink-0 text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors whitespace-nowrap"
+                >
+                  {step.cta}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default OnboardingChecklist;

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -46,9 +46,17 @@ const Dashboard: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
   const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null);
-  const [onboardingDismissed, setOnboardingDismissed] = useState(
-    () => localStorage.getItem("onboarding_dismissed") === "true",
-  );
+  const [onboardingDismissed, setOnboardingDismissed] = useState(false);
+
+  useEffect(() => {
+    try {
+      setOnboardingDismissed(
+        window.localStorage.getItem("onboarding_dismissed") === "true",
+      );
+    } catch {
+      /* restricted storage mode */
+    }
+  }, []);
 
   const fetchData = useCallback(async () => {
     try {
@@ -57,7 +65,12 @@ const Dashboard: React.FC = () => {
           api.get("/vault/entries"),
           api.get("/successors"),
           api.get("/activity?limit=5"),
-          api.get("/inactivity/settings").catch(() => null),
+          api.get("/inactivity/settings").catch((err: unknown) => {
+            const status = (err as { response?: { status?: number } })?.response
+              ?.status;
+            if (status === 404) return null;
+            throw err;
+          }),
         ]);
 
       // Vault returns array directly

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -8,6 +8,9 @@ import {
 import api from "../services/api";
 import { Link } from "react-router-dom";
 import { useToast } from "../contexts/ToastContext";
+import OnboardingChecklist, {
+  type SetupStatus,
+} from "../components/OnboardingChecklist";
 
 interface ActivityLog {
   id: string;
@@ -42,21 +45,43 @@ const Dashboard: React.FC = () => {
   const [activities, setActivities] = useState<ActivityLog[]>([]);
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
+  const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null);
+  const [onboardingDismissed, setOnboardingDismissed] = useState(
+    () => localStorage.getItem("onboarding_dismissed") === "true",
+  );
 
   const fetchData = useCallback(async () => {
     try {
-      const [vaultRes, successorsRes, activityRes] = await Promise.all([
-        api.get("/vault/entries"),
-        api.get("/successors"),
-        api.get("/activity?limit=5"),
-      ]);
+      const [vaultRes, successorsRes, activityRes, inactivityRes] =
+        await Promise.all([
+          api.get("/vault/entries"),
+          api.get("/successors"),
+          api.get("/activity?limit=5"),
+          api.get("/inactivity/settings").catch(() => null),
+        ]);
 
       // Vault returns array directly
       const vaultCount = Array.isArray(vaultRes.data)
         ? vaultRes.data.length
         : 0;
       // Successors returns { successors: [...] }
-      const successorCount = successorsRes.data.successors?.length || 0;
+      const successors = successorsRes.data.successors || [];
+      const successorCount = successors.length;
+
+      const hasKeyShares = successors.some(
+        (s: { encryptedShare?: string | null }) => !!s.encryptedShare,
+      );
+
+      const inactivitySettings = inactivityRes?.data;
+      const hasInactivityConfig =
+        !!inactivitySettings && inactivitySettings.thresholdDays > 0;
+
+      setSetupStatus({
+        hasSecrets: vaultCount > 0,
+        hasSuccessors: successorCount > 0,
+        hasKeyShares,
+        hasInactivityConfig,
+      });
 
       // Calculate days active from user account creation date
       const daysActive = user?.createdAt
@@ -156,6 +181,18 @@ const Dashboard: React.FC = () => {
           </Link>
         </div>
       </div>
+
+      {setupStatus && !onboardingDismissed && !loading && (
+        <div className="mt-8">
+          <OnboardingChecklist
+            status={setupStatus}
+            onDismiss={() => {
+              setOnboardingDismissed(true);
+              localStorage.setItem("onboarding_dismissed", "true");
+            }}
+          />
+        </div>
+      )}
 
       <div className="mt-8">
         <h3 className="text-base font-semibold leading-6 text-gray-900">

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -1,5 +1,6 @@
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   ShieldCheckIcon,
   ClockIcon,
@@ -7,7 +8,62 @@ import {
   UserGroupIcon,
   LockClosedIcon,
   DocumentTextIcon,
+  ChevronDownIcon,
 } from "@heroicons/react/24/outline";
+
+const faqItems = [
+  {
+    question: "What exactly is a Dead Man's Switch?",
+    answer:
+      "A Dead Man's Switch is a safety mechanism that activates when you stop responding. You set a check-in interval (e.g., every 30 days). If you fail to check in within that window, HandoverKey assumes something has happened and begins the handover process to your designated successors. Simply logging in or clicking a link in a reminder email resets the timer.",
+  },
+  {
+    question: "Can HandoverKey staff read my data?",
+    answer:
+      "No. HandoverKey uses zero-knowledge encryption — your data is encrypted on your device using a key derived from your master password before it ever leaves your browser. Our servers only store ciphertext. We never see your password or your decrypted data, and we have no way to recover it. If you lose your master password, your data is unrecoverable.",
+  },
+  {
+    question: "What happens if I forget to check in?",
+    answer:
+      "First, we'll send you multiple reminders via email as your timer approaches expiration. If you still don't check in, HandoverKey enters a Warning Phase (a grace period, typically 48 hours) where we attempt to reach you more aggressively. Only after this grace period passes without any response does the handover to your successors actually begin. You can cancel the handover at any time during the grace period by simply logging in.",
+  },
+  {
+    question: "What is Shamir's Secret Sharing and why does it matter?",
+    answer:
+      "Shamir's Secret Sharing is a cryptographic technique that splits your encryption key into multiple shares distributed among your successors. You can configure it so that a minimum number of successors (e.g., 3 out of 5) must combine their shares to reconstruct the key. This means no single successor can access your data alone — they must cooperate, preventing premature or unauthorized access.",
+  },
+  {
+    question: "Can I give different secrets to different successors?",
+    answer:
+      "Yes. You can assign specific vault entries to specific successors. For example, your spouse might receive financial credentials while a business partner receives company-related secrets. You can also restrict successors to only see the entries explicitly assigned to them.",
+  },
+  {
+    question: "Do my successors need a HandoverKey account?",
+    answer:
+      "No. Successors are identified by their email address and verified through a one-time email link. When a handover triggers, they receive their key share and a secure access link. They combine the required shares in their browser to decrypt the data — no account, no installation, everything happens in the browser.",
+  },
+  {
+    question: "What can I store in my vault?",
+    answer:
+      "You can store passwords, API keys, cryptocurrency seed phrases, personal notes, legal documents, and files. Everything is organized by category and tags, and you can search, export, and import your vault data at any time. All data is encrypted client-side before storage.",
+  },
+  {
+    question: "What happens if HandoverKey shuts down?",
+    answer:
+      "HandoverKey is open source, so you can always self-host it. Additionally, the Export feature lets you download your entire encrypted vault as a JSON file at any time. Your encryption keys and data are never locked into our platform. We recommend keeping regular exports as a backup.",
+  },
+  {
+    question: "Can I pause the Dead Man's Switch temporarily?",
+    answer:
+      "Yes. If you're going on vacation or know you'll be unavailable, you can pause your inactivity monitoring from your Settings page. While paused, missing a check-in won't trigger any handover process. You can resume monitoring whenever you're ready.",
+  },
+  {
+    question:
+      "How is this different from just sharing my passwords with someone?",
+    answer:
+      "Sharing passwords directly means someone else has access to your accounts right now, which is a security risk. HandoverKey ensures your successors only gain access after the Dead Man's Switch triggers — not before. Combined with Shamir's Secret Sharing, even the successors can't access your data prematurely since no individual holds enough key material alone.",
+  },
+];
 
 export default function LandingPage() {
   return (
@@ -138,6 +194,51 @@ export default function LandingPage() {
         </div>
       </div>
 
+      {/* FAQ Section */}
+      <div className="py-24 bg-gray-50">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+              Frequently Asked Questions
+            </h2>
+            <p className="text-lg text-gray-600">
+              Everything you need to know about securing your digital legacy
+              with HandoverKey.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {faqItems.map((item, index) => (
+              <FAQItem
+                key={index}
+                question={item.question}
+                answer={item.answer}
+              />
+            ))}
+          </div>
+
+          <div className="mt-12 text-center">
+            <p className="text-gray-600">
+              Still have questions?{" "}
+              <Link
+                to="/contact"
+                className="text-blue-600 font-medium hover:text-blue-700 transition-colors"
+              >
+                Get in touch
+              </Link>{" "}
+              or read our detailed{" "}
+              <Link
+                to="/how-it-works"
+                className="text-blue-600 font-medium hover:text-blue-700 transition-colors"
+              >
+                How it Works
+              </Link>{" "}
+              guide.
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* CTA Section */}
       <div className="bg-gray-900 py-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -204,5 +305,43 @@ function FeatureCard({
       <h3 className="text-xl font-bold text-gray-900 mb-3">{title}</h3>
       <p className="text-gray-600 leading-relaxed">{description}</p>
     </motion.div>
+  );
+}
+
+function FAQItem({ question, answer }: { question: string; answer: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between p-6 text-left hover:bg-gray-50 transition-colors"
+      >
+        <span className="text-lg font-semibold text-gray-900 pr-4">
+          {question}
+        </span>
+        <motion.div
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+          className="flex-shrink-0"
+        >
+          <ChevronDownIcon className="w-5 h-5 text-gray-500" />
+        </motion.div>
+      </button>
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+          >
+            <div className="px-6 pb-6 text-gray-600 leading-relaxed">
+              {answer}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/packages/shared/src/utils/constants.ts
+++ b/packages/shared/src/utils/constants.ts
@@ -16,8 +16,8 @@ export const API_ENDPOINTS = {
   },
   HANDOVER: {
     STATUS: "/api/v1/handover/status",
-    CHECK_IN: "/api/v1/handover/check-in",
-    AUDIT_LOGS: "/api/v1/handover/audit-logs",
+    CANCEL: "/api/v1/handover/cancel",
+    RESPOND: "/api/v1/handover/respond",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- **Landing Page FAQ**: Added a 10-item interactive accordion FAQ section between the feature grid and CTA, covering trust concerns (zero-knowledge, data loss), handover mechanics (grace period, Shamir's), and practical questions (pause switch, no-account successors, open source fallback).
- **Handover API Routes**: Wired up the `HandoverOrchestrator` methods that were implemented but never exposed via HTTP -- `GET /api/v1/handover/status`, `POST /api/v1/handover/cancel`, and `POST /api/v1/handover/respond` (public, rate-limited successor accept/decline endpoint). Added Zod validation schemas and updated the stale `API_ENDPOINTS.HANDOVER` constants in `packages/shared`.
- **Onboarding Checklist**: Added a guided setup checklist to the Dashboard that appears for new users, tracking 4 steps: add first secret, designate a successor, generate key shares, configure inactivity settings. Auto-hides when all steps are complete, dismissible via localStorage.

## Test plan

- [ ] Landing page: verify FAQ accordion expands/collapses, all 10 items render, "Get in touch" and "How it Works" links work
- [ ] `GET /api/v1/handover/status` returns `{ active: false }` for a user with no active handover
- [ ] `POST /api/v1/handover/cancel` returns 404 when no active handover exists
- [ ] `POST /api/v1/handover/respond` validates token and returns appropriate errors for invalid tokens
- [ ] Dashboard: onboarding checklist appears for a fresh user with 0 secrets/successors
- [ ] Dashboard: checklist auto-hides when all 4 steps are completed
- [ ] Dashboard: dismiss button persists dismissal across page reloads (localStorage)
- [ ] Existing auth, vault, and successor flows are unaffected