### PR TITLE
fix: auto-include www variant in CORS allowed origins

### DIFF
--- a/.cursor/rules/workflow-preferences.mdc
+++ b/.cursor/rules/workflow-preferences.mdc
@@ -1,0 +1,32 @@
+---
+description: User workflow preferences — git hygiene, validation gates, and branch management
+alwaysApply: true
+---
+
+# Workflow Preferences
+
+## Pre-Push Validation
+
+Always run lint, build, and test (in that order) **before** pushing any commit. Never push code that hasn't passed all three gates locally.
+
+```bash
+npm run lint && npm run build && npm test
+```
+
+If any step fails, fix the issue and re-run all gates before pushing.
+
+## Git Branch Hygiene
+
+- Before starting new work, always check whether the current PR/branch has already been merged.
+- For new tasks: switch to `main`, pull the latest, then create a fresh branch.
+- Never push new work to a branch whose PR is already merged.
+
+```bash
+git checkout main && git pull origin main
+git checkout -b <new-branch>
+```
+
+## Commit Style
+
+- Follow Conventional Commits: `feat:`, `fix:`, `build:`, `docs:`, `test:`, `refactor:`.
+- Commit messages should focus on the "why", not the "what".

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,5 +13,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v4
+        if: steps.release.outputs.releases_created == 'true'
+
+      - uses: actions/setup-node@v4
+        if: steps.release.outputs.releases_created == 'true'
+        with:
+          node-version: "22"
+
+      - name: Format generated files
+        if: steps.release.outputs.releases_created == 'true'
+        run: npx prettier --write CHANGELOG.md .release-please-manifest.json
+
+      - name: Commit formatted files
+        if: steps.release.outputs.releases_created == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md .release-please-manifest.json
+          git diff --cached --quiet || git commit -m "chore: format release files with Prettier"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0](https://github.com/HandoverKey/HandoverKey/compare/v1.0.0...v1.1.0) (2026-04-20)
 
-
 ### Features
 
-* add FAQ section, handover routes, and onboarding checklist ([#222](https://github.com/HandoverKey/HandoverKey/issues/222)) ([f94cbaf](https://github.com/HandoverKey/HandoverKey/commit/f94cbaf0abcddfc936752da83d9e8497c257ffe8))
-
+- add FAQ section, handover routes, and onboarding checklist ([#222](https://github.com/HandoverKey/HandoverKey/issues/222)) ([f94cbaf](https://github.com/HandoverKey/HandoverKey/commit/f94cbaf0abcddfc936752da83d9e8497c257ffe8))
 
 ### Bug Fixes
 
-* improve UX across auth, vault, and successor flows ([#223](https://github.com/HandoverKey/HandoverKey/issues/223)) ([bac8cb1](https://github.com/HandoverKey/HandoverKey/commit/bac8cb14216ed9daa8ca324c1910bae066a38c84))
-* resolve all Dependabot security vulnerabilities ([#226](https://github.com/HandoverKey/HandoverKey/issues/226)) ([e12c7e6](https://github.com/HandoverKey/HandoverKey/commit/e12c7e681ffbf3678bc72b062e92bd5212ff0d16))
+- improve UX across auth, vault, and successor flows ([#223](https://github.com/HandoverKey/HandoverKey/issues/223)) ([bac8cb1](https://github.com/HandoverKey/HandoverKey/commit/bac8cb14216ed9daa8ca324c1910bae066a38c84))
+- resolve all Dependabot security vulnerabilities ([#226](https://github.com/HandoverKey/HandoverKey/issues/226)) ([e12c7e6](https://github.com/HandoverKey/HandoverKey/commit/e12c7e681ffbf3678bc72b062e92bd5212ff0d16))
 
 ## [1.0.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The platform works as a dead man's switch:
 
 ## Project Status
 
-`v1.0.0` is the current release.
+`v1.1.0` is the current release. <!-- x-release-please-version -->
 
 The repository now ships a production-grade web app and API with:
 

--- a/apps/api/src/__tests__/integration/cors.test.ts
+++ b/apps/api/src/__tests__/integration/cors.test.ts
@@ -1,6 +1,5 @@
-import { URL } from "node:url";
 import request from "supertest";
-import app from "../../app";
+import app, { buildAllowedOrigins } from "../../app";
 
 describe("CORS", () => {
   const allowedOrigin = process.env.FRONTEND_URL || "http://localhost:5173";
@@ -15,18 +14,38 @@ describe("CORS", () => {
     expect(res.headers["access-control-allow-credentials"]).toBe("true");
   });
 
-  it("allows the www variant of the configured origin", async () => {
-    const url = new URL(allowedOrigin);
-    const wwwOrigin = url.hostname.startsWith("www.")
-      ? allowedOrigin
-      : `${url.protocol}//www.${url.hostname}${url.port ? `:${url.port}` : ""}`;
+  it("allows the www variant for apex domains", () => {
+    const origins = buildAllowedOrigins("https://handoverkey.com");
 
-    const res = await request(app)
-      .options("/api/v1/auth/profile")
-      .set("Origin", wwwOrigin)
-      .set("Access-Control-Request-Method", "GET");
+    expect(origins.has("https://handoverkey.com")).toBe(true);
+    expect(origins.has("https://www.handoverkey.com")).toBe(true);
+  });
 
-    expect(res.headers["access-control-allow-origin"]).toBe(wwwOrigin);
+  it("strips www for www-prefixed apex domains", () => {
+    const origins = buildAllowedOrigins("https://www.handoverkey.com");
+
+    expect(origins.has("https://www.handoverkey.com")).toBe(true);
+    expect(origins.has("https://handoverkey.com")).toBe(true);
+  });
+
+  it("does not add www variant for subdomains", () => {
+    const origins = buildAllowedOrigins("https://app.example.com");
+
+    expect(origins.has("https://app.example.com")).toBe(true);
+    expect(origins.has("https://www.app.example.com")).toBe(false);
+  });
+
+  it("normalises origins via url.origin", () => {
+    const origins = buildAllowedOrigins("https://Example.COM:443/path/");
+
+    expect(origins.has("https://example.com")).toBe(true);
+  });
+
+  it("skips malformed origins", () => {
+    const origins = buildAllowedOrigins("not-a-url, https://valid.com");
+
+    expect(origins.has("not-a-url")).toBe(false);
+    expect(origins.has("https://valid.com")).toBe(true);
   });
 
   it("rejects requests from disallowed origins", async () => {
@@ -38,9 +57,12 @@ describe("CORS", () => {
     expect(res.headers["access-control-allow-origin"]).toBeUndefined();
   });
 
-  it("allows requests with no Origin header (server-to-server)", async () => {
-    const res = await request(app).get("/health");
+  it("passes requests with no Origin header through CORS", async () => {
+    const res = await request(app)
+      .get("/api/v1/auth/profile")
+      .set("Accept", "application/json");
 
-    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(res.status).not.toBe(500);
   });
 });

--- a/apps/api/src/__tests__/integration/cors.test.ts
+++ b/apps/api/src/__tests__/integration/cors.test.ts
@@ -1,3 +1,4 @@
+import { URL } from "node:url";
 import request from "supertest";
 import app from "../../app";
 

--- a/apps/api/src/__tests__/integration/cors.test.ts
+++ b/apps/api/src/__tests__/integration/cors.test.ts
@@ -1,0 +1,45 @@
+import request from "supertest";
+import app from "../../app";
+
+describe("CORS", () => {
+  const allowedOrigin = process.env.FRONTEND_URL || "http://localhost:5173";
+
+  it("allows requests from the configured FRONTEND_URL", async () => {
+    const res = await request(app)
+      .options("/api/v1/auth/profile")
+      .set("Origin", allowedOrigin)
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.headers["access-control-allow-origin"]).toBe(allowedOrigin);
+    expect(res.headers["access-control-allow-credentials"]).toBe("true");
+  });
+
+  it("allows the www variant of the configured origin", async () => {
+    const url = new URL(allowedOrigin);
+    const wwwOrigin = url.hostname.startsWith("www.")
+      ? allowedOrigin
+      : `${url.protocol}//www.${url.hostname}${url.port ? `:${url.port}` : ""}`;
+
+    const res = await request(app)
+      .options("/api/v1/auth/profile")
+      .set("Origin", wwwOrigin)
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.headers["access-control-allow-origin"]).toBe(wwwOrigin);
+  });
+
+  it("rejects requests from disallowed origins", async () => {
+    const res = await request(app)
+      .options("/api/v1/auth/profile")
+      .set("Origin", "https://evil.example.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("allows requests with no Origin header (server-to-server)", async () => {
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,3 +1,4 @@
+import { URL } from "node:url";
 import express from "express";
 import cookieParser from "cookie-parser";
 import cors from "cors";

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -104,18 +104,31 @@ app.use(
   }) as unknown as express.RequestHandler,
 );
 
-const ALLOWED_ORIGINS = (
-  process.env.CORS_ORIGINS ||
-  process.env.FRONTEND_URL ||
-  "http://localhost:5173"
-)
-  .split(",")
-  .map((o) => o.trim());
+const ALLOWED_ORIGINS = new Set(
+  (
+    process.env.CORS_ORIGINS ||
+    process.env.FRONTEND_URL ||
+    "http://localhost:5173"
+  )
+    .split(",")
+    .flatMap((o) => {
+      const origin = o.trim();
+      try {
+        const url = new URL(origin);
+        const wwwVariant = url.hostname.startsWith("www.")
+          ? `${url.protocol}//${url.hostname.slice(4)}${url.port ? `:${url.port}` : ""}`
+          : `${url.protocol}//www.${url.hostname}${url.port ? `:${url.port}` : ""}`;
+        return [origin, wwwVariant];
+      } catch {
+        return [origin];
+      }
+    }),
+);
 
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin || ALLOWED_ORIGINS.includes(origin)) {
+      if (!origin || ALLOWED_ORIGINS.has(origin)) {
         callback(null, true);
       } else {
         callback(new Error(`Origin ${origin} not allowed by CORS`));

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -109,7 +109,7 @@ app.use(
 // www / non-www counterpart (apex domains only) so that
 // FRONTEND_URL=https://handoverkey.com automatically permits
 // https://www.handoverkey.com and vice-versa.
-function buildAllowedOrigins(raw: string): Set<string> {
+export function buildAllowedOrigins(raw: string): Set<string> {
   const origins = new Set<string>();
 
   for (const entry of raw.split(",")) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -104,25 +104,49 @@ app.use(
   }) as unknown as express.RequestHandler,
 );
 
-const ALLOWED_ORIGINS = new Set(
-  (
-    process.env.CORS_ORIGINS ||
+// Build the CORS allowlist. For each configured origin we also allow the
+// www / non-www counterpart (apex domains only) so that
+// FRONTEND_URL=https://handoverkey.com automatically permits
+// https://www.handoverkey.com and vice-versa.
+function buildAllowedOrigins(raw: string): Set<string> {
+  const origins = new Set<string>();
+
+  for (const entry of raw.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      logger.warn({ origin: trimmed }, "Ignoring malformed CORS origin");
+      continue;
+    }
+
+    // url.origin normalises scheme + host + port (strips paths, trailing slashes)
+    origins.add(parsed.origin);
+
+    const parts = parsed.hostname.split(".");
+    if (parsed.hostname.startsWith("www.") && parts.length === 3) {
+      // www.example.com -> also allow example.com
+      const bare = new URL(parsed.origin);
+      bare.hostname = parsed.hostname.slice(4);
+      origins.add(bare.origin);
+    } else if (parts.length === 2) {
+      // example.com -> also allow www.example.com
+      const www = new URL(parsed.origin);
+      www.hostname = `www.${parsed.hostname}`;
+      origins.add(www.origin);
+    }
+  }
+
+  return origins;
+}
+
+const ALLOWED_ORIGINS = buildAllowedOrigins(
+  process.env.CORS_ORIGINS ||
     process.env.FRONTEND_URL ||
-    "http://localhost:5173"
-  )
-    .split(",")
-    .flatMap((o) => {
-      const origin = o.trim();
-      try {
-        const url = new URL(origin);
-        const wwwVariant = url.hostname.startsWith("www.")
-          ? `${url.protocol}//${url.hostname.slice(4)}${url.port ? `:${url.port}` : ""}`
-          : `${url.protocol}//www.${url.hostname}${url.port ? `:${url.port}` : ""}`;
-        return [origin, wwwVariant];
-      } catch {
-        return [origin];
-      }
-    }),
+    "http://localhost:5173",
 );
 
 app.use(

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,14 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "extra-files": ["docs/openapi.yaml"]
+      "extra-files": [
+        "docs/openapi.yaml",
+        {
+          "type": "generic",
+          "path": "README.md",
+          "glob": false
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes CORS rejection for `www.handoverkey.com` when `FRONTEND_URL` is set to `handoverkey.com`
- Each configured origin now automatically generates both the `www` and non-`www` variant
- Switches the allowlist from an array (`.includes()`) to a `Set` (`.has()`) for O(1) lookups

## Test plan

- [x] API build passes
- [ ] Verify `www.handoverkey.com` can reach `api.handoverkey.com` without CORS errors
- [ ] Verify `handoverkey.com` still works
- [ ] Verify `localhost:5173` still works in development