### PR TITLE
fix: exclude release-please files from prettier checks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,27 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v4
-        if: steps.release.outputs.releases_created == 'true'
-
-      - uses: actions/setup-node@v4
-        if: steps.release.outputs.releases_created == 'true'
-        with:
-          node-version: "22"
-
-      - name: Format generated files
-        if: steps.release.outputs.releases_created == 'true'
-        run: npx prettier --write CHANGELOG.md .release-please-manifest.json
-
-      - name: Commit formatted files
-        if: steps.release.outputs.releases_created == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md .release-please-manifest.json
-          git diff --cached --quiet || git commit -m "chore: format release files with Prettier"
-          git push

--- a/.prettierignore
+++ b/.prettierignore
@@ -26,3 +26,7 @@ coverage/
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+# Auto-generated release files (managed by release-please)
+CHANGELOG.md
+.release-please-manifest.json


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` and `.release-please-manifest.json` to `.prettierignore` so the CI prettier check no longer flags auto-generated release files
- Remove the broken post-release formatting steps from `release-please.yml` — branch protection rules block direct pushes to `main`, so the commit+push approach cannot work

## Context

After a release, `release-please` generates `CHANGELOG.md` with its own formatting. The previous workflow attempted to reformat these files and push directly to `main`, which violates the branch protection rules (required status checks + PR-only changes).

## Test plan

- [ ] CI lint/format check passes (CHANGELOG.md no longer checked by prettier)
- [ ] Release-please workflow no longer has the broken post-release steps
- [ ] Future releases don't trigger formatting failures