### PR TITLE
fix: resolve Redis initialization race condition on startup

### DIFF
--- a/.cursor/rules/workflow-preferences.mdc
+++ b/.cursor/rules/workflow-preferences.mdc
@@ -15,6 +15,23 @@ npm run lint && npm run build && npm test
 
 If any step fails, fix the issue and re-run all gates before pushing.
 
+## Local Verification
+
+When fixing runtime or deployment issues, verify the fix locally before pushing. Spin up the required infrastructure (Redis, Postgres) via Docker containers, run the app, and confirm the fix works end-to-end.
+
+```bash
+docker run -d --name redis-test -p 6379:6379 redis:7-alpine
+docker run -d --name postgres-test -p 5432:5432 \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=handoverkey_dev postgres:16-alpine
+```
+
+Clean up containers after verification:
+
+```bash
+docker stop redis-test postgres-test && docker rm redis-test postgres-test
+```
+
 ## Git Branch Hygiene
 
 - Before starting new work, always check whether the current PR/branch has already been merged.

--- a/apps/api/src/config/redis.ts
+++ b/apps/api/src/config/redis.ts
@@ -2,45 +2,61 @@ import { createClient, RedisClientType } from "redis";
 import { logger } from "./logger";
 
 let redisClient: RedisClientType | null = null;
+let redisInitPromise: Promise<void> | null = null;
 
 /**
- * Initialize Redis client
+ * Initialize Redis client. Concurrency-safe: concurrent callers share a
+ * single init promise. On failure the state resets so the next call retries.
  */
 export async function initializeRedis(): Promise<void> {
   if (redisClient) {
     return;
   }
 
-  redisClient = createClient({
-    socket: {
-      host: process.env.REDIS_HOST || "localhost",
-      port: parseInt(process.env.REDIS_PORT || "6379"),
-      reconnectStrategy: (retries) => {
-        const delay = Math.min(Math.pow(2, retries) * 1000, 30000);
-        logger.warn({ attempt: retries, delay }, "Retrying Redis connection");
-        return delay;
+  if (redisInitPromise) {
+    return redisInitPromise;
+  }
+
+  redisInitPromise = (async () => {
+    const client: RedisClientType = createClient({
+      socket: {
+        host: process.env.REDIS_HOST || "localhost",
+        port: parseInt(process.env.REDIS_PORT || "6379"),
+        reconnectStrategy: (retries) => {
+          const delay = Math.min(Math.pow(2, retries) * 1000, 30000);
+          logger.warn({ attempt: retries, delay }, "Retrying Redis connection");
+          return delay;
+        },
       },
-    },
-    password: process.env.REDIS_PASSWORD,
-  });
+      password: process.env.REDIS_PASSWORD,
+    });
 
-  redisClient.on("error", (error) => {
-    logger.error({ error }, "Redis client error");
-  });
+    client.on("error", (error) => {
+      logger.error({ error }, "Redis client error");
+    });
 
-  redisClient.on("connect", () => {
-    logger.info("Redis client connected");
-  });
+    client.on("connect", () => {
+      logger.info("Redis client connected");
+    });
 
-  redisClient.on("ready", () => {
-    logger.info("Redis client ready");
-  });
+    client.on("ready", () => {
+      logger.info("Redis client ready");
+    });
 
-  redisClient.on("reconnecting", () => {
-    logger.warn("Redis client reconnecting");
-  });
+    client.on("reconnecting", () => {
+      logger.warn("Redis client reconnecting");
+    });
 
-  await redisClient.connect();
+    try {
+      await client.connect();
+      redisClient = client;
+    } catch (error) {
+      redisInitPromise = null;
+      throw error;
+    }
+  })();
+
+  return redisInitPromise;
 }
 
 /**

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -7,7 +7,8 @@ let cachedSendCommand: SendCommandFn | null = null;
 
 async function getSendCommand(): Promise<SendCommandFn> {
   if (!cachedSendCommand) {
-    const { getRedisClient } = await import("../config/redis");
+    const { initializeRedis, getRedisClient } = await import("../config/redis");
+    await initializeRedis();
     const client = getRedisClient();
     cachedSendCommand = ((...args: string[]) =>
       client.sendCommand(args)) as SendCommandFn;


### PR DESCRIPTION
## Summary

- Fix startup crash: `Redis client not initialized. Call initializeRedis() first.`
- Root cause: `RedisStore` (rate-limit-redis) fires `loadIncrementScript()` as a background async operation during construction at module import time, racing with `initializeRedis()` which runs later in the `appInit` promise chain
- Fix: call `initializeRedis()` inside `getSendCommand()` before accessing the client — it's idempotent so safe to call from multiple sites

## Context

In production, the rate limiter uses a Redis-backed store (`RedisStore`). The store's constructor triggers an async `loadIncrementScript()` that calls `sendCommand` -> `getSendCommand()` -> `getRedisClient()`. Since module imports happen before `appInit` resolves, Redis isn't connected yet and `getRedisClient()` throws.

## Test plan

- [ ] Deploy to production — app starts without Redis initialization error
- [ ] Rate limiting still works correctly with Redis store
- [ ] Existing integration tests pass (CI)