### PR TITLE
fix: admin panel nav visibility, audit trail, and activity display

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,6 +26,9 @@ JOB_CONCURRENCY=5
 GRACE_PERIOD_HOURS=48
 
 # Admin Configuration (comma-separated list of admin email addresses)
+# Users whose email is listed here see the Admin nav link and can access
+# the admin dashboard, user management, and account unlock features.
+# Example: ADMIN_EMAILS=admin@example.com,ops@example.com
 ADMIN_EMAILS=
 
 # Security Configuration

--- a/apps/api/src/__tests__/integration/admin-dashboard.test.ts
+++ b/apps/api/src/__tests__/integration/admin-dashboard.test.ts
@@ -86,5 +86,33 @@ describe("Admin Dashboard Integration", () => {
       .executeTakeFirstOrThrow();
     expect(unlocked.failed_login_attempts).toBe(0);
     expect(unlocked.locked_until).toBeNull();
+
+    const auditRecords = await db
+      .selectFrom("activity_records")
+      .select(["activity_type", "metadata"])
+      .where("user_id", "=", admin.userId)
+      .where("activity_type", "like", "ADMIN_%")
+      .orderBy("created_at", "asc")
+      .execute();
+
+    const types = auditRecords.map((r) => r.activity_type);
+    expect(types).toContain("ADMIN_VIEW_DASHBOARD");
+    expect(types).toContain("ADMIN_LIST_USERS");
+    expect(types).toContain("ADMIN_UNLOCKED_ACCOUNT");
+
+    const unlockRecord = auditRecords.find(
+      (r) => r.activity_type === "ADMIN_UNLOCKED_ACCOUNT",
+    );
+    expect(unlockRecord?.metadata).toMatchObject({
+      targetUserId: target.userId,
+      targetEmail: target.email,
+    });
+
+    const listRecord = auditRecords.find(
+      (r) => r.activity_type === "ADMIN_LIST_USERS",
+    );
+    expect(listRecord?.metadata).toMatchObject({
+      search: target.email,
+    });
   });
 });

--- a/apps/api/src/__tests__/integration/auth-full.test.ts
+++ b/apps/api/src/__tests__/integration/auth-full.test.ts
@@ -28,6 +28,8 @@ async function registerVerifyLogin(emailPrefix: string) {
 }
 
 describe("Auth Full Flow Integration", () => {
+  const originalAdminEmails = process.env.ADMIN_EMAILS;
+
   beforeAll(async () => {
     const dbClient = getDatabaseClient();
     await dbClient.initialize({
@@ -45,6 +47,7 @@ describe("Auth Full Flow Integration", () => {
   });
 
   afterAll(async () => {
+    process.env.ADMIN_EMAILS = originalAdminEmails;
     await closeRedis();
     await getDatabaseClient().close();
   });
@@ -60,6 +63,41 @@ describe("Auth Full Flow Integration", () => {
     expect(res.body.user).toHaveProperty("id");
     expect(res.body.user).toHaveProperty("email");
     expect(res.body.user).toHaveProperty("name");
+  });
+
+  it("should return role 'user' for non-admin login and profile", async () => {
+    const { token } = await registerVerifyLogin("role-user");
+    process.env.ADMIN_EMAILS = "someone-else@example.com";
+
+    const profileRes = await request(app)
+      .get("/api/v1/auth/profile")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(profileRes.status).toBe(200);
+    expect(profileRes.body.user.role).toBe("user");
+  });
+
+  it("should return role 'admin' for allowlisted email on login and profile", async () => {
+    const { email, password } = await registerVerifyLogin("role-admin");
+    process.env.ADMIN_EMAILS = email;
+
+    const loginRes = await request(app)
+      .post("/api/v1/auth/login")
+      .send({ email, password });
+    expect(loginRes.status).toBe(200);
+    expect(loginRes.body.user.role).toBe("admin");
+
+    const cookies = loginRes.headers["set-cookie"];
+    const accessCookie = (Array.isArray(cookies) ? cookies : [cookies]).find(
+      (c: string) => c?.startsWith("accessToken="),
+    );
+    const token = accessCookie!.split(";")[0].split("=")[1];
+
+    const profileRes = await request(app)
+      .get("/api/v1/auth/profile")
+      .set("Authorization", `Bearer ${token}`);
+    expect(profileRes.status).toBe(200);
+    expect(profileRes.body.user.role).toBe("admin");
   });
 
   it("should reject profile request without auth", async () => {

--- a/apps/api/src/controllers/admin-controller.ts
+++ b/apps/api/src/controllers/admin-controller.ts
@@ -64,6 +64,12 @@ export class AdminController {
           .execute(),
       ]);
 
+      await UserService.logActivity(
+        req.user.userId,
+        "ADMIN_VIEW_DASHBOARD",
+        req.ip,
+      );
+
       res.json({
         stats: {
           totalUsers: Number(totalUsersResult.count),
@@ -128,6 +134,14 @@ export class AdminController {
       }
 
       const users = await query.execute();
+
+      await UserService.logActivity(
+        req.user.userId,
+        "ADMIN_LIST_USERS",
+        req.ip,
+        { search: search || undefined, resultCount: users.length },
+      );
+
       res.json({
         users: users.map((user) => ({
           id: user.id,
@@ -169,11 +183,11 @@ export class AdminController {
       // Unlock the account
       await AccountLockoutService.unlockAccount(userId);
 
-      // Log the action
       await UserService.logActivity(
         req.user.userId,
         "ADMIN_UNLOCKED_ACCOUNT",
         req.ip,
+        { targetUserId: userId, targetEmail: user.email },
       );
 
       res.json({
@@ -213,6 +227,13 @@ export class AdminController {
       const attemptCount = await AccountLockoutService.getAttemptCount(userId);
       const timeUntilUnlock =
         await AccountLockoutService.getTimeUntilUnlock(userId);
+
+      await UserService.logActivity(
+        req.user.userId,
+        "ADMIN_VIEW_LOCKOUT_STATUS",
+        req.ip,
+        { targetUserId: userId, targetEmail: user.email },
+      );
 
       res.json({
         userId: user.id,

--- a/apps/api/src/controllers/auth-controller.ts
+++ b/apps/api/src/controllers/auth-controller.ts
@@ -476,6 +476,7 @@ export class AuthController {
           id: updatedUser.id,
           email: updatedUser.email,
           name: updatedUser.name,
+          role: isAdmin(updatedUser.email) ? "admin" : "user",
           twoFactorEnabled: updatedUser.twoFactorEnabled,
           lastActivity: updatedUser.lastActivity,
           createdAt: updatedUser.createdAt,

--- a/apps/api/src/controllers/auth-controller.ts
+++ b/apps/api/src/controllers/auth-controller.ts
@@ -11,6 +11,11 @@ import {
   NotFoundError,
   EmailVerificationRequiredError,
 } from "../errors";
+import { getAdminEmails } from "../middleware/admin";
+
+function isAdmin(email: string): boolean {
+  return getAdminEmails().includes(email.toLowerCase());
+}
 
 function getCookieDomain(): string | undefined {
   return process.env.COOKIE_DOMAIN || undefined;
@@ -184,6 +189,7 @@ export class AuthController {
           id: user.id,
           email: user.email,
           name: user.name,
+          role: isAdmin(user.email) ? "admin" : "user",
           twoFactorEnabled: user.twoFactorEnabled,
           lastActivity: user.lastActivity,
           salt: Buffer.from(user.salt).toString("base64"),
@@ -430,6 +436,7 @@ export class AuthController {
           id: user.id,
           email: user.email,
           name: user.name,
+          role: isAdmin(user.email) ? "admin" : "user",
           twoFactorEnabled: user.twoFactorEnabled,
           lastActivity: user.lastActivity,
           createdAt: user.createdAt,

--- a/apps/api/src/middleware/admin.ts
+++ b/apps/api/src/middleware/admin.ts
@@ -2,7 +2,7 @@ import { Response, NextFunction } from "express";
 import { AuthenticatedRequest } from "./auth";
 import { AuthorizationError } from "../errors";
 
-function getAdminEmails(): string[] {
+export function getAdminEmails(): string[] {
   return (process.env.ADMIN_EMAILS || "")
     .split(",")
     .map((e) => e.trim().toLowerCase())

--- a/apps/api/src/services/user-service.ts
+++ b/apps/api/src/services/user-service.ts
@@ -445,6 +445,7 @@ export class UserService {
     userId: string,
     activityType: string,
     ipAddress?: string,
+    metadata?: Record<string, unknown>,
   ): Promise<void> {
     try {
       const activityRepo = this.getActivityRepository();
@@ -452,6 +453,7 @@ export class UserService {
         user_id: userId,
         activity_type: activityType,
         ip_address: ipAddress,
+        metadata: metadata ?? null,
       });
 
       // Also update user's last_activity

--- a/apps/web/src/pages/AdminDashboard.tsx
+++ b/apps/web/src/pages/AdminDashboard.tsx
@@ -10,6 +10,11 @@ interface DashboardStats {
   activeHandovers: number;
 }
 
+interface ActivityEntry {
+  type: string;
+  count: number;
+}
+
 interface UserRow {
   id: string;
   email: string;
@@ -24,6 +29,7 @@ interface UserRow {
 const AdminDashboard: React.FC = () => {
   const { success, error: showError } = useToast();
   const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [activity, setActivity] = useState<ActivityEntry[]>([]);
   const [users, setUsers] = useState<UserRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
@@ -36,6 +42,7 @@ const AdminDashboard: React.FC = () => {
         api.get("/admin/users?limit=25"),
       ]);
       setStats(statsResponse.data?.stats || null);
+      setActivity(statsResponse.data?.activityLast24h || []);
       setUsers(usersResponse.data?.users || []);
       setIsForbidden(false);
     } catch (err) {
@@ -133,6 +140,32 @@ const AdminDashboard: React.FC = () => {
           </p>
         </div>
       </div>
+
+      {activity.length > 0 && (
+        <div className="card p-4 mb-8">
+          <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider mb-3">
+            Activity (Last 24h)
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {activity.map((entry) => (
+              <div
+                key={entry.type}
+                className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2"
+              >
+                <span className="text-sm text-gray-700 truncate mr-2">
+                  {entry.type
+                    .replace(/_/g, " ")
+                    .toLowerCase()
+                    .replace(/\b\w/g, (c) => c.toUpperCase())}
+                </span>
+                <span className="text-sm font-semibold text-gray-900">
+                  {entry.count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="card p-4 mb-4">
         <div className="flex gap-2">


### PR DESCRIPTION
## Summary

- **Fix admin nav link**: Return `role` field in login/profile API responses by checking user email against `ADMIN_EMAILS`. The sidebar "Admin" link was always hidden because the API never sent `role`, even though `Layout.tsx` checks `user?.role === "admin"`.

- **Comprehensive audit trail**: All admin controller actions now log activity records:
  - `ADMIN_VIEW_DASHBOARD` -- when admin opens dashboard
  - `ADMIN_LIST_USERS` -- with search query and result count in metadata
  - `ADMIN_UNLOCKED_ACCOUNT` -- now includes target userId and email in metadata
  - `ADMIN_VIEW_LOCKOUT_STATUS` -- with target userId and email in metadata

- **Activity display**: Render the 24h activity type breakdown in the admin dashboard UI. The API already returned `activityLast24h` but the frontend was ignoring it.

## Changes

| File | Change |
|------|--------|
| `apps/api/src/middleware/admin.ts` | Export `getAdminEmails()` for reuse |
| `apps/api/src/controllers/auth-controller.ts` | Add `role` to login and profile responses |
| `apps/api/src/services/user-service.ts` | Accept optional `metadata` param in `logActivity` |
| `apps/api/src/controllers/admin-controller.ts` | Add audit logging to all 4 admin actions |
| `apps/web/src/pages/AdminDashboard.tsx` | Render 24h activity breakdown section |

## How to access admin panel

1. Set `ADMIN_EMAILS=your-email@example.com` in your `.env`
2. Log in with that email
3. The "Admin" link now appears in the sidebar navigation

## Test plan

- [ ] Log in as admin email -- verify "Admin" nav link appears
- [ ] Log in as non-admin email -- verify "Admin" nav link does NOT appear
- [ ] Open admin dashboard -- verify 24h activity section renders
- [ ] Unlock a user -- verify activity log includes target user metadata
- [ ] CI passes (lint, build, test)