### PR TITLE
fix: close critical zero-knowledge & dead-man's-switch trust gaps

### DIFF
--- a/apps/api/src/__tests__/integration/handover-flow.test.ts
+++ b/apps/api/src/__tests__/integration/handover-flow.test.ts
@@ -84,6 +84,22 @@ describe("Handover Flow Integration", () => {
     await getDatabaseClient().close();
   });
 
+  it("should create default inactivity settings on registration", async () => {
+    const email = `enroll-test-${Date.now()}@example.com`;
+    const { userId } = await register(email);
+
+    const db = getDatabaseClient().getKysely();
+    const settings = await db
+      .selectFrom("inactivity_settings")
+      .selectAll()
+      .where("user_id", "=", userId)
+      .executeTakeFirst();
+
+    expect(settings).toBeDefined();
+    expect(settings!.threshold_days).toBe(90);
+    expect(settings!.is_paused).toBe(false);
+  });
+
   it("should store encrypted key share when adding a successor", async () => {
     const email = `share-test-${Date.now()}@example.com`;
     await register(email);
@@ -189,7 +205,7 @@ describe("Handover Flow Integration", () => {
     // Since we are monitoring logs in the run output, we can see if it worked.
   });
 
-  it("should deny successor access during grace period and allow after expiration", async () => {
+  it("should deny successor access until the successor accepts (1-of-1)", async () => {
     const email = `access-test-${Date.now()}@example.com`;
     const { userId } = await register(email);
     const token = await login(email);
@@ -232,24 +248,36 @@ describe("Handover Flow Integration", () => {
     const process = await orchestrator.initiateHandover(userId);
     expect(process.status).toBe(HandoverProcessStatus.GRACE_PERIOD);
 
-    // 5. Successor tries to verify/access -> Should fail (403 or logic specific)
-    // Actually, verify endpoint might work (to show status), but access endpoint should fail.
+    // 5. Email-verify the successor (confirms ownership of email).
     const verifyRes = await request(app).get(
       `/api/v1/successors/verify?token=${verificationToken}`,
     );
     expect(verifyRes.status).toBe(200);
 
-    // 6. Successor tries to GET vault entries -> Should be 403 Forbidden
+    // 6. Access during grace period -> 403 (not yet open).
     const accessRes = await request(app).get(
       `/api/v1/vault/successor-access?token=${verificationToken}`,
     );
     expect(accessRes.status).toBe(403);
     expect(accessRes.body.error).toMatch(/not yet open/i);
 
-    // 7. Expire Grace Period
+    // 7. Expire grace period -> AWAITING_SUCCESSORS + notifications created.
     await orchestrator.processGracePeriodExpiration(process.id);
 
-    // 8. Successor tries to GET vault entries -> Should be 200 OK
+    // 8. Access after expiration but BEFORE accepting -> 403 (must accept).
+    const beforeAccept = await request(app).get(
+      `/api/v1/vault/successor-access?token=${verificationToken}`,
+    );
+    expect(beforeAccept.status).toBe(403);
+    expect(beforeAccept.body.error).toMatch(/accept the handover/i);
+
+    // 9. Successor accepts the handover.
+    const respondRes = await request(app)
+      .post("/api/v1/handover/respond")
+      .send({ token: verificationToken, accepted: true });
+    expect(respondRes.status).toBe(200);
+
+    // 10. Now access is allowed (1-of-1 threshold met -> released).
     const accessResAllowed = await request(app).get(
       `/api/v1/vault/successor-access?token=${verificationToken}`,
     );
@@ -260,13 +288,13 @@ describe("Handover Flow Integration", () => {
     );
   });
 
-  it("should complete handover when all successors respond via processSuccessorResponse", async () => {
+  it("should require the K-of-N acceptance threshold before completing", async () => {
     const email = `respond-test-${Date.now()}@example.com`;
     const { userId } = await register(email);
     const token = await login(email);
     const auth = { Authorization: `Bearer ${token}` };
 
-    // 1. Add two successors
+    // 1. Add two successors (default threshold = min(2, N) = 2-of-2).
     const s1 = await request(app).post("/api/v1/successors").set(auth).send({
       email: "resp-successor-1@example.com",
       name: "Resp Successor 1",
@@ -283,34 +311,21 @@ describe("Handover Flow Integration", () => {
     const successorId1 = s1.body.successor.id;
     const successorId2 = s2.body.successor.id;
 
-    // 2. Initiate handover and move past grace period
+    // 2. Initiate handover and move past grace period (orchestrator creates
+    //    the successor_notifications rows itself).
     const orchestrator = new HandoverOrchestrator();
     const handover = await orchestrator.initiateHandover(userId);
     await orchestrator.processGracePeriodExpiration(handover.id);
 
-    // 3. Create successor_notifications for both successors
     const db = getDatabaseClient().getKysely();
-    const deadline = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-
-    await db
-      .insertInto("successor_notifications")
-      .values([
-        {
-          handover_process_id: handover.id,
-          successor_id: successorId1,
-          response_deadline: deadline,
-          verification_token: null,
-        },
-        {
-          handover_process_id: handover.id,
-          successor_id: successorId2,
-          response_deadline: deadline,
-          verification_token: null,
-        },
-      ])
+    const notifications = await db
+      .selectFrom("successor_notifications")
+      .selectAll()
+      .where("handover_process_id", "=", handover.id)
       .execute();
+    expect(notifications).toHaveLength(2);
 
-    // 4. First successor responds -- handover should NOT complete yet
+    // 3. First successor accepts -- below threshold, must NOT complete.
     await orchestrator.processSuccessorResponse(handover.id, successorId1, {
       accepted: true,
     });
@@ -322,18 +337,9 @@ describe("Handover Flow Integration", () => {
       .executeTakeFirstOrThrow();
     expect(afterFirst.status).toBe(HandoverProcessStatus.AWAITING_SUCCESSORS);
 
-    // Verify notification status updated to VERIFIED
-    const n1 = await db
-      .selectFrom("successor_notifications")
-      .select("verification_status")
-      .where("handover_process_id", "=", handover.id)
-      .where("successor_id", "=", successorId1)
-      .executeTakeFirstOrThrow();
-    expect(n1.verification_status).toBe("VERIFIED");
-
-    // 5. Second successor responds -- handover should now COMPLETE
+    // 4. Second successor accepts -- threshold reached -> COMPLETED.
     await orchestrator.processSuccessorResponse(handover.id, successorId2, {
-      accepted: false,
+      accepted: true,
     });
 
     const afterSecond = await db
@@ -342,15 +348,55 @@ describe("Handover Flow Integration", () => {
       .where("id", "=", handover.id)
       .executeTakeFirstOrThrow();
     expect(afterSecond.status).toBe(HandoverProcessStatus.COMPLETED);
+  });
 
-    // Verify second notification status is DECLINED
-    const n2 = await db
-      .selectFrom("successor_notifications")
-      .select("verification_status")
-      .where("handover_process_id", "=", handover.id)
-      .where("successor_id", "=", successorId2)
+  it("should expire (not complete) when not enough successors accept", async () => {
+    const email = `decline-test-${Date.now()}@example.com`;
+    const { userId } = await register(email);
+    const token = await login(email);
+    const auth = { Authorization: `Bearer ${token}` };
+
+    const s1 = await request(app).post("/api/v1/successors").set(auth).send({
+      email: "decline-successor-1@example.com",
+      name: "Decline Successor 1",
+      handoverDelayDays: 7,
+      encryptedShare: "share-1",
+    });
+    const s2 = await request(app).post("/api/v1/successors").set(auth).send({
+      email: "decline-successor-2@example.com",
+      name: "Decline Successor 2",
+      handoverDelayDays: 7,
+      encryptedShare: "share-2",
+    });
+
+    const orchestrator = new HandoverOrchestrator();
+    const handover = await orchestrator.initiateHandover(userId);
+    await orchestrator.processGracePeriodExpiration(handover.id);
+
+    // One accepts, one declines: acceptedCount (1) < threshold (2) and all
+    // responded -> EXPIRED, vault never released.
+    await orchestrator.processSuccessorResponse(
+      handover.id,
+      s1.body.successor.id,
+      {
+        accepted: true,
+      },
+    );
+    await orchestrator.processSuccessorResponse(
+      handover.id,
+      s2.body.successor.id,
+      {
+        accepted: false,
+      },
+    );
+
+    const db = getDatabaseClient().getKysely();
+    const final = await db
+      .selectFrom("handover_processes")
+      .select("status")
+      .where("id", "=", handover.id)
       .executeTakeFirstOrThrow();
-    expect(n2.verification_status).toBe("DECLINED");
+    expect(final.status).toBe(HandoverProcessStatus.EXPIRED);
   });
 
   it("should handle bulk update of successor shares", async () => {

--- a/apps/api/src/__tests__/integration/handover-routes.test.ts
+++ b/apps/api/src/__tests__/integration/handover-routes.test.ts
@@ -139,6 +139,7 @@ describe("Handover Routes Integration", () => {
 
       const orchestrator = new HandoverOrchestrator();
       const handover = await orchestrator.initiateHandover(user.userId);
+      // Grace expiration creates the successor_notifications rows itself.
       await orchestrator.processGracePeriodExpiration(handover.id);
 
       const db = getDatabaseClient().getKysely();
@@ -148,25 +149,6 @@ describe("Handover Routes Integration", () => {
         .select("verification_token")
         .where("user_id", "=", user.userId)
         .executeTakeFirstOrThrow();
-
-      const deadline = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-      const successorRows = await db
-        .selectFrom("successors")
-        .select("id")
-        .where("user_id", "=", user.userId)
-        .execute();
-
-      await db
-        .insertInto("successor_notifications")
-        .values(
-          successorRows.map((s) => ({
-            handover_process_id: handover.id,
-            successor_id: s.id,
-            response_deadline: deadline,
-            verification_token: null,
-          })),
-        )
-        .execute();
 
       const res = await request(app).post("/api/v1/handover/respond").send({
         token: successor.verification_token,

--- a/apps/api/src/__tests__/integration/vault-and-successors.test.ts
+++ b/apps/api/src/__tests__/integration/vault-and-successors.test.ts
@@ -238,6 +238,12 @@ describe("Vault and Successors Integration", () => {
     const process = await orchestrator.initiateHandover(userId);
     await orchestrator.processGracePeriodExpiration(process.id);
 
+    // Successor must accept before access is granted (1-of-1 threshold).
+    const respondRes = await request(app)
+      .post("/api/v1/handover/respond")
+      .send({ token: verificationToken, accepted: true });
+    expect(respondRes.status).toBe(200);
+
     const successorAccess = await request(app).get(
       `/api/v1/vault/successor-access?token=${verificationToken}`,
     );

--- a/apps/api/src/controllers/vault-controller.ts
+++ b/apps/api/src/controllers/vault-controller.ts
@@ -2,9 +2,9 @@ import { Request, Response, NextFunction } from "express";
 import { VaultService } from "../services/vault-service";
 import { UserService } from "../services/user-service";
 import { SuccessorService } from "../services/successor-service";
+import { HandoverOrchestrator } from "../services/handover-orchestrator";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { AuthenticationError, NotFoundError } from "../errors";
-import { HandoverProcessStatus } from "@handoverkey/shared/src/types/dead-mans-switch";
 
 export class VaultController {
   static async createEntry(
@@ -249,31 +249,35 @@ export class VaultController {
       // 1. Verify successor token and get metadata
       const result = await SuccessorService.verifySuccessorByToken(token);
 
-      if (!result.success || !result.userId) {
+      if (!result.success || !result.userId || !result.successorId) {
         throw new AuthenticationError("Invalid or expired verification token");
       }
 
-      // 2. Check handover status
-      const allowedStatuses: string[] = [
-        HandoverProcessStatus.AWAITING_SUCCESSORS,
-        HandoverProcessStatus.COMPLETED,
-      ];
-      if (
-        !result.handoverStatus ||
-        !allowedStatuses.includes(result.handoverStatus)
-      ) {
+      // 2. Gate access on: handover past grace period, THIS successor having
+      //    accepted, and the K-of-N acceptance threshold being met.
+      const orchestrator = new HandoverOrchestrator();
+      const decision = await orchestrator.getSuccessorAccessDecision(
+        result.userId,
+        result.successorId,
+      );
+
+      if (!decision.allowed) {
         res.status(403).json({
-          error: "Handover access is not yet open",
-          status: result.handoverStatus,
+          error: decision.reason || "Handover access is not yet open",
+          status: decision.status,
+          acceptedCount: decision.acceptedCount,
+          threshold: decision.threshold,
         });
         return;
       }
 
-      // 3. Get encrypted entries
-      const entries = await VaultService.getSuccessorEntries(
-        result.userId,
-        result.successorId,
-      );
+      // 3. Get encrypted entries and the successor's own wrapped share. The
+      //    wrapped share is useless without the out-of-band passphrase, so it
+      //    is safe to return here for client-side unwrap + reconstruction.
+      const [entries, successor] = await Promise.all([
+        VaultService.getSuccessorEntries(result.userId, result.successorId),
+        SuccessorService.getSuccessor(result.userId, result.successorId),
+      ]);
 
       // Log the access
       await UserService.logActivity(
@@ -300,6 +304,9 @@ export class VaultController {
 
       res.json({
         ownerName: result.userName,
+        wrappedShare: successor?.encryptedShare ?? null,
+        threshold: decision.threshold,
+        acceptedCount: decision.acceptedCount,
         entries: responseEntries,
       });
     } catch (error) {

--- a/apps/api/src/services/handover-orchestrator.ts
+++ b/apps/api/src/services/handover-orchestrator.ts
@@ -2,6 +2,8 @@ import {
   getDatabaseClient,
   HandoverProcessRepository,
   SuccessorNotificationRepository,
+  SuccessorRepository,
+  InactivitySettingsRepository,
 } from "@handoverkey/database";
 import {
   HandoverOrchestrator as IHandoverOrchestrator,
@@ -14,6 +16,16 @@ import { logger } from "../config/logger";
 import { realtimeService } from "./realtime-service";
 
 const GRACE_PERIOD_HOURS = parseInt(process.env.GRACE_PERIOD_HOURS || "48", 10);
+const DEFAULT_RESPONSE_WINDOW_DAYS = 14;
+
+export interface SuccessorAccessDecision {
+  allowed: boolean;
+  reason?: string;
+  status?: string;
+  acceptedCount: number;
+  threshold: number;
+  totalNotified: number;
+}
 
 export class HandoverOrchestrator implements IHandoverOrchestrator {
   private static getHandoverProcessRepository(): HandoverProcessRepository {
@@ -24,6 +36,38 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
   private static getSuccessorNotificationRepository(): SuccessorNotificationRepository {
     const dbClient = getDatabaseClient();
     return new SuccessorNotificationRepository(dbClient.getKysely());
+  }
+
+  private static getSuccessorRepository(): SuccessorRepository {
+    const dbClient = getDatabaseClient();
+    return new SuccessorRepository(dbClient.getKysely());
+  }
+
+  private static getInactivitySettingsRepository(): InactivitySettingsRepository {
+    const dbClient = getDatabaseClient();
+    return new InactivitySettingsRepository(dbClient.getKysely());
+  }
+
+  /**
+   * Computes the K-of-N threshold required to release the vault, mirroring the
+   * client-side share-splitting logic so the server can enforce it.
+   */
+  static computeThreshold(
+    successorCount: number,
+    requireMajority: boolean,
+  ): number {
+    if (successorCount <= 1) {
+      return successorCount;
+    }
+    return requireMajority
+      ? Math.floor(successorCount / 2) + 1
+      : Math.min(2, successorCount);
+  }
+
+  private async getRequireMajority(userId: string): Promise<boolean> {
+    const settingsRepo = HandoverOrchestrator.getInactivitySettingsRepository();
+    const settings = await settingsRepo.findByUserId(userId);
+    return Boolean(settings?.require_majority);
   }
 
   /**
@@ -184,6 +228,19 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
         return;
       }
 
+      const terminalStatuses: string[] = [
+        HandoverProcessStatus.COMPLETED,
+        HandoverProcessStatus.CANCELLED,
+        HandoverProcessStatus.EXPIRED,
+      ];
+      if (terminalStatuses.includes(handoverProcess.status)) {
+        logger.info(
+          { handoverId, status: handoverProcess.status },
+          "Ignoring successor response -- handover already in terminal state",
+        );
+        return;
+      }
+
       const notificationRepo =
         HandoverOrchestrator.getSuccessorNotificationRepository();
       await notificationRepo.update(handoverId, successorId, {
@@ -199,24 +256,26 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
 
       const allNotifications =
         await notificationRepo.findByHandoverProcess(handoverId);
-      const allResponded = allNotifications.every(
+      const acceptedCount = allNotifications.filter(
+        (n) => n.verification_status === "VERIFIED",
+      ).length;
+      const respondedCount = allNotifications.filter(
         (n) =>
           n.verification_status === "VERIFIED" ||
           n.verification_status === "DECLINED",
+      ).length;
+      const totalNotified = allNotifications.length;
+
+      const requireMajority = await this.getRequireMajority(
+        handoverProcess.user_id,
+      );
+      const threshold = HandoverOrchestrator.computeThreshold(
+        totalNotified,
+        requireMajority,
       );
 
-      if (allResponded) {
-        if (
-          handoverProcess.status === HandoverProcessStatus.COMPLETED ||
-          handoverProcess.status === HandoverProcessStatus.CANCELLED
-        ) {
-          logger.info(
-            { handoverId, status: handoverProcess.status },
-            "Skipping completion -- handover already in terminal state",
-          );
-          return;
-        }
-
+      // Vault is only released once the K-of-N acceptance threshold is met.
+      if (acceptedCount >= threshold && threshold > 0) {
         await handoverRepo.update(handoverId, {
           status: HandoverProcessStatus.COMPLETED,
           completed_at: new Date(),
@@ -228,7 +287,30 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
           { handoverId, status: HandoverProcessStatus.COMPLETED },
         );
 
-        logger.info({ handoverId }, "Handover process completed");
+        logger.info(
+          { handoverId, acceptedCount, threshold },
+          "Handover process completed -- acceptance threshold reached",
+        );
+        return;
+      }
+
+      // Everyone responded but not enough accepted (e.g. all declined): the
+      // handover expires WITHOUT releasing the vault.
+      if (respondedCount === totalNotified && acceptedCount < threshold) {
+        await handoverRepo.update(handoverId, {
+          status: HandoverProcessStatus.EXPIRED,
+        });
+
+        realtimeService.broadcastToUser(
+          handoverProcess.user_id,
+          "handover.status_changed",
+          { handoverId, status: HandoverProcessStatus.EXPIRED },
+        );
+
+        logger.info(
+          { handoverId, acceptedCount, threshold },
+          "Handover expired -- not enough successors accepted",
+        );
       }
     } catch (error) {
       if (process.env.NODE_ENV !== "test") {
@@ -291,20 +373,38 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
         `Grace period expired for handover ${handoverId}, notifying successors`,
       );
 
-      // Notify successors
-      const dbClient = getDatabaseClient();
-      const successorRepo = new (
-        await import("@handoverkey/database")
-      ).SuccessorRepository(dbClient.getKysely());
+      const successorRepo = HandoverOrchestrator.getSuccessorRepository();
       const successors = await successorRepo.findByUserId(process.user_id);
-      // Notification sent with key share
+
+      // Create successor_notification rows so accept/decline + K-of-N
+      // completion works in the real handover path (not just in tests).
+      const notificationRepo =
+        HandoverOrchestrator.getSuccessorNotificationRepository();
+      const existing = await notificationRepo.findByHandoverProcess(handoverId);
+      if (existing.length === 0) {
+        const now = Date.now();
+        for (const successor of successors) {
+          const windowDays =
+            successor.handover_delay_days || DEFAULT_RESPONSE_WINDOW_DAYS;
+          await notificationRepo.create({
+            handover_process_id: handoverId,
+            successor_id: successor.id,
+            response_deadline: new Date(now + windowDays * 24 * 60 * 60 * 1000),
+            verification_status: "PENDING",
+            verification_token: null,
+          });
+        }
+      }
+
+      // Notify successors. The email NEVER contains the key share itself; it
+      // only links to the access page where the successor unwraps their share
+      // with the out-of-band passphrase provided by the owner.
       const notificationService = new NotificationService();
       await notificationService.sendHandoverAlert(
         process.user_id,
         successors.map((s) => ({
           name: s.name,
           email: s.email,
-          encrypted_share: s.encrypted_share,
           verification_token: s.verification_token,
         })),
         handoverId,
@@ -369,6 +469,87 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
       }
       return [];
     }
+  }
+
+  /**
+   * Determines whether a specific (already email-verified) successor may access
+   * the owner's vault. Access requires:
+   *   1. A handover that has moved past the grace period.
+   *   2. This successor having ACCEPTED (verification_status = VERIFIED).
+   *   3. The K-of-N acceptance threshold being met across all successors.
+   */
+  async getSuccessorAccessDecision(
+    userId: string,
+    successorId: string,
+  ): Promise<SuccessorAccessDecision> {
+    const handoverRepo = HandoverOrchestrator.getHandoverProcessRepository();
+    const latest = await handoverRepo.findLatestByUserId(userId);
+
+    const base = { acceptedCount: 0, threshold: 0, totalNotified: 0 };
+
+    const openStatuses: string[] = [
+      HandoverProcessStatus.AWAITING_SUCCESSORS,
+      HandoverProcessStatus.VERIFICATION_PENDING,
+      HandoverProcessStatus.READY_FOR_TRANSFER,
+      HandoverProcessStatus.COMPLETED,
+    ];
+
+    if (!latest || !openStatuses.includes(latest.status)) {
+      return {
+        ...base,
+        allowed: false,
+        reason: "Handover access is not yet open",
+        status: latest?.status,
+      };
+    }
+
+    const notificationRepo =
+      HandoverOrchestrator.getSuccessorNotificationRepository();
+    const notifications = await notificationRepo.findByHandoverProcess(
+      latest.id,
+    );
+    const totalNotified = notifications.length;
+    const acceptedCount = notifications.filter(
+      (n) => n.verification_status === "VERIFIED",
+    ).length;
+    const requireMajority = await this.getRequireMajority(userId);
+    const threshold = HandoverOrchestrator.computeThreshold(
+      totalNotified,
+      requireMajority,
+    );
+
+    const mine = notifications.find((n) => n.successor_id === successorId);
+    if (!mine || mine.verification_status !== "VERIFIED") {
+      return {
+        ...base,
+        allowed: false,
+        reason: "You must accept the handover before accessing the vault",
+        status: latest.status,
+        acceptedCount,
+        threshold,
+        totalNotified,
+      };
+    }
+
+    if (acceptedCount < threshold) {
+      return {
+        allowed: false,
+        reason:
+          "Waiting for enough successors to accept before the vault can be released",
+        status: latest.status,
+        acceptedCount,
+        threshold,
+        totalNotified,
+      };
+    }
+
+    return {
+      allowed: true,
+      status: latest.status,
+      acceptedCount,
+      threshold,
+      totalNotified,
+    };
   }
 
   /**

--- a/apps/api/src/services/handover-orchestrator.ts
+++ b/apps/api/src/services/handover-orchestrator.ts
@@ -385,7 +385,7 @@ export class HandoverOrchestrator implements IHandoverOrchestrator {
         const now = Date.now();
         for (const successor of successors) {
           const windowDays =
-            successor.handover_delay_days || DEFAULT_RESPONSE_WINDOW_DAYS;
+            successor.handover_delay_days ?? DEFAULT_RESPONSE_WINDOW_DAYS;
           await notificationRepo.create({
             handover_process_id: handoverId,
             successor_id: successor.id,

--- a/apps/api/src/services/notification-service.ts
+++ b/apps/api/src/services/notification-service.ts
@@ -156,7 +156,6 @@ export class NotificationService implements INotificationService {
         const content = this.createHandoverAlertContent(
           successor.name || "Successor",
           successor.email,
-          successor.encrypted_share,
           successor.verification_token,
         );
 
@@ -457,20 +456,27 @@ export class NotificationService implements INotificationService {
   private createHandoverAlertContent(
     successorName: string,
     _successorEmail: string,
-    encryptedShare?: string | null,
     verificationToken?: string | null,
   ): { subject: string; html: string } {
     const baseUrl = process.env.FRONTEND_URL || "http://localhost:5173";
     const successorAccessLink = verificationToken
       ? `${baseUrl}/successor-access?token=${verificationToken}`
       : `${baseUrl}/verify-successor`;
-    const shareSection = encryptedShare
-      ? `YOUR KEY SHARE:\n${encryptedShare}\n\nStore this securely.`
-      : "No key share was attached to this notification.";
 
-    const securityWarning = encryptedShare
-      ? "Security warning: this share is sensitive. Store it in a secure channel."
-      : "If you expected a key share, contact support.";
+    // Zero-knowledge: key shares are NEVER sent by email. The encrypted share
+    // lives in the successor portal and can only be unwrapped with the recovery
+    // passphrase the account owner gave you separately (in person, sealed
+    // letter, password manager, etc.).
+    const shareSection =
+      "No key share is included in this email for your security. " +
+      "Your encrypted share is waiting in the successor portal and can only be " +
+      "unlocked with the recovery passphrase the account owner shared with you " +
+      "separately.";
+
+    const securityWarning =
+      "HandoverKey will never email you a key share or ask for your recovery " +
+      "passphrase. Open the successor portal and follow the guided steps to " +
+      "unlock the vault.";
 
     return {
       subject: "HandoverKey: Digital Asset Handover Initiated",

--- a/apps/api/src/services/user-service.ts
+++ b/apps/api/src/services/user-service.ts
@@ -2,6 +2,7 @@ import {
   getDatabaseClient,
   UserRepository,
   ActivityRepository,
+  InactivitySettingsRepository,
   type Database,
   type Transaction,
 } from "@handoverkey/database";
@@ -40,6 +41,37 @@ export class UserService {
   private static getActivityRepository(): ActivityRepository {
     const dbClient = getDatabaseClient();
     return new ActivityRepository(dbClient.getKysely());
+  }
+
+  private static getInactivitySettingsRepository(): InactivitySettingsRepository {
+    const dbClient = getDatabaseClient();
+    return new InactivitySettingsRepository(dbClient.getKysely());
+  }
+
+  /**
+   * Ensures a user has a default inactivity_settings row so the dead-man's
+   * switch actually monitors them. Safe to call repeatedly (no-op if exists).
+   */
+  static async ensureInactivitySettings(userId: string): Promise<void> {
+    const settingsRepo = this.getInactivitySettingsRepository();
+    try {
+      const existing = await settingsRepo.findByUserId(userId);
+      if (existing) {
+        return;
+      }
+      await settingsRepo.create({
+        user_id: userId,
+        threshold_days: 90,
+        notification_methods: ["email"],
+        is_paused: false,
+      });
+    } catch (error) {
+      // A concurrent insert (unique PK violation) is fine; otherwise log.
+      logger.warn(
+        { err: error, userId },
+        "Failed to ensure default inactivity settings",
+      );
+    }
   }
 
   static async createUser(
@@ -94,6 +126,10 @@ export class UserService {
       }
       throw error;
     }
+
+    // Enroll the new user in the dead-man's switch by creating default
+    // inactivity settings, so the inactivity monitor tracks them immediately.
+    await this.ensureInactivitySettings(dbUser.id);
 
     // Send verification email (don't fail registration if email fails)
     try {

--- a/apps/web/src/pages/SuccessorAccess.tsx
+++ b/apps/web/src/pages/SuccessorAccess.tsx
@@ -6,8 +6,9 @@ import {
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import api from "../services/api";
+import { getApiErrorMessage } from "../services/api-error";
 import { useToast } from "../contexts/ToastContext";
-import { reconstructSecret } from "@handoverkey/crypto";
+import { reconstructSecret, unwrapShare } from "@handoverkey/crypto";
 import { importRawMasterKey, decryptDataWithKey } from "../services/encryption";
 
 interface VaultEntry {
@@ -51,8 +52,10 @@ const SuccessorAccess: React.FC = () => {
     handoverStatus?: string;
   }>({});
 
-  const [myShare, setMyShare] = useState("");
+  const [myPassphrase, setMyPassphrase] = useState("");
   const [peerShares, setPeerShares] = useState<string[]>([""]);
+  const [accepting, setAccepting] = useState(false);
+  const [accepted, setAccepted] = useState(false);
   const [decryptedEntries, setDecryptedEntries] = useState<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Array<VaultEntry & { decryptedData: any }>
@@ -113,43 +116,72 @@ const SuccessorAccess: React.FC = () => {
     setPeerShares(newShares);
   };
 
+  const base64ToBytes = (value: string): Uint8Array => {
+    const binary = atob(value.trim());
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  };
+
+  const handleAcceptHandover = async () => {
+    setAccepting(true);
+    try {
+      await api.post("/handover/respond", { token, accepted: true });
+      setAccepted(true);
+      success("Handover accepted. You can now unlock the vault below.");
+    } catch (err) {
+      showError(getApiErrorMessage(err, "Failed to accept the handover"));
+    } finally {
+      setAccepting(false);
+    }
+  };
+
   const handleUnlockVault = async () => {
-    if (!myShare) {
-      showError("Please enter your key share.");
+    if (!myPassphrase) {
+      showError("Please enter your recovery passphrase.");
       return;
     }
-
-    const allShares = [myShare, ...peerShares.filter((s) => s.trim() !== "")];
 
     setUnlocking(true);
     info("Reconstructing key and decrypting vault...");
 
     try {
-      // 1. Fetch encrypted entries
+      // 1. Fetch encrypted entries + this successor's wrapped share. Returns
+      //    403 until the K-of-N acceptance threshold is met.
       const response = await api.get(`/vault/successor-access?token=${token}`);
       const encryptedEntries: VaultEntry[] = response.data.entries;
+      const wrappedShare: string | null = response.data.wrappedShare;
 
-      // 2. Convert shares from Base64 string to Uint8Array
-      const shareBuffers = allShares.map((s) => {
-        try {
-          const binary = atob(s);
-          const bytes = new Uint8Array(binary.length);
-          for (let i = 0; i < binary.length; i++) {
-            bytes[i] = binary.charCodeAt(i);
-          }
-          return bytes;
-        } catch {
-          throw new Error("Invalid base64 share provided");
-        }
-      });
+      if (!wrappedShare) {
+        showError(
+          "No key share is on file for you. Ask the account owner to (re)generate and distribute shares.",
+        );
+        return;
+      }
 
-      // 3. Reconstruct secret
-      const rawMasterKey = reconstructSecret(shareBuffers);
+      // 2. Unwrap our own share with the out-of-band recovery passphrase.
+      let myShareBytes: Uint8Array;
+      try {
+        myShareBytes = await unwrapShare(wrappedShare, myPassphrase.trim());
+      } catch {
+        showError(
+          "Could not unlock your share. Double-check the recovery passphrase the owner gave you.",
+        );
+        return;
+      }
 
-      // 4. Import key
+      // 3. Combine with any peer shares (already-unwrapped Base64 values that
+      //    co-successors shared out-of-band).
+      const peerBytes = peerShares
+        .filter((s) => s.trim() !== "")
+        .map((s) => base64ToBytes(s));
+
+      const rawMasterKey = reconstructSecret([myShareBytes, ...peerBytes]);
+
+      // 4. Import key + decrypt entries locally.
       const masterKey = await importRawMasterKey(rawMasterKey);
-
-      // 5. Decrypt entries
       const decrypted = await Promise.all(
         encryptedEntries.map(async (entry) => {
           const data = await decryptDataWithKey(
@@ -165,7 +197,10 @@ const SuccessorAccess: React.FC = () => {
     } catch (err) {
       console.error("Unlock failed", err);
       showError(
-        "Failed to unlock vault. Please check if you have entered enough valid shares.",
+        getApiErrorMessage(
+          err,
+          "Failed to unlock vault. Make sure you and enough co-successors have accepted, and that your shares are correct.",
+        ),
       );
     } finally {
       setUnlocking(false);
@@ -270,38 +305,69 @@ const SuccessorAccess: React.FC = () => {
                     </div>
                     <div className="ml-3">
                       <p className="text-sm text-yellow-700 dark:text-yellow-300">
-                        To unlock this vault, you need to combine your unique
-                        key share with shares from other successors. The total
-                        number of shares must meet the threshold set by the
-                        owner.
+                        First confirm you are taking over this account. Then
+                        unlock your encrypted share with the recovery passphrase
+                        the owner gave you separately, and combine it with
+                        shares from enough co-successors to meet the
+                        owner&apos;s threshold.
                       </p>
                     </div>
                   </div>
                 </div>
 
+                <div className="rounded-md border border-gray-200 dark:border-gray-700 p-4">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    Step 1 &mdash; Confirm the handover
+                  </p>
+                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    The vault is only released once enough successors confirm.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handleAcceptHandover}
+                    disabled={accepting || accepted}
+                    className="mt-3 btn btn-secondary"
+                  >
+                    {accepted
+                      ? "Handover accepted"
+                      : accepting
+                        ? "Accepting..."
+                        : "Accept handover"}
+                  </button>
+                </div>
+
                 <div className="grid grid-cols-1 gap-y-6 sm:grid-cols-2 sm:gap-x-8">
                   <div className="sm:col-span-2">
+                    <p className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+                      Step 2 &mdash; Unlock the vault
+                    </p>
                     <label
-                      htmlFor="my-share"
+                      htmlFor="my-passphrase"
                       className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
-                      Your Key Share (Base64)
+                      Your recovery passphrase
                     </label>
                     <div className="mt-1">
-                      <textarea
-                        id="my-share"
-                        rows={3}
-                        className="input font-mono text-xs"
-                        placeholder="Paste your share here..."
-                        value={myShare}
-                        onChange={(e) => setMyShare(e.target.value)}
+                      <input
+                        id="my-passphrase"
+                        type="text"
+                        autoComplete="off"
+                        className="input font-mono"
+                        placeholder="e.g. ABCDE-FGHJK-LMNPQ-RSTUV"
+                        value={myPassphrase}
+                        onChange={(e) => setMyPassphrase(e.target.value)}
                       />
                     </div>
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      This is the passphrase the account owner gave you in
+                      person, by letter, or via a password manager &mdash; not a
+                      HandoverKey password.
+                    </p>
                   </div>
 
                   <div className="sm:col-span-2">
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Peer Key Shares
+                      Co-successor key shares (Base64)
                     </label>
                     <div className="space-y-4">
                       {peerShares.map((share, index) => (
@@ -338,7 +404,7 @@ const SuccessorAccess: React.FC = () => {
                 <div className="pt-5">
                   <button
                     onClick={handleUnlockVault}
-                    disabled={unlocking || !myShare}
+                    disabled={unlocking || !myPassphrase}
                     className="w-full btn btn-primary py-3 text-lg flex justify-center items-center gap-2"
                   >
                     {unlocking ? (

--- a/apps/web/src/pages/SuccessorAccess.tsx
+++ b/apps/web/src/pages/SuccessorAccess.tsx
@@ -117,7 +117,16 @@ const SuccessorAccess: React.FC = () => {
   };
 
   const base64ToBytes = (value: string): Uint8Array => {
-    const binary = atob(value.trim());
+    // Strip all whitespace/newlines that may have crept in when a share was
+    // copied around, so a stray line break doesn't surface as a cryptic
+    // DOMException from atob().
+    const sanitized = value.replace(/\s+/g, "");
+    let binary: string;
+    try {
+      binary = atob(sanitized);
+    } catch {
+      throw new Error("Invalid share: not valid Base64 data.");
+    }
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
       bytes[i] = binary.charCodeAt(i);

--- a/apps/web/src/pages/Successors.tsx
+++ b/apps/web/src/pages/Successors.tsx
@@ -463,8 +463,14 @@ const Successors: React.FC = () => {
                     <button
                       type="button"
                       onClick={() => {
+                        if (!navigator.clipboard?.writeText) {
+                          showError(
+                            "Clipboard not available. Copy the passphrase manually.",
+                          );
+                          return;
+                        }
                         navigator.clipboard
-                          ?.writeText(passphrase)
+                          .writeText(passphrase)
                           .then(() => success("Passphrase copied"))
                           .catch(() => showError("Failed to copy"));
                       }}

--- a/apps/web/src/pages/Successors.tsx
+++ b/apps/web/src/pages/Successors.tsx
@@ -6,7 +6,11 @@ import { getApiErrorMessage } from "../services/api-error";
 import { useToast } from "../contexts/ToastContext";
 import ConfirmationModal from "../components/ConfirmationModal";
 import UpgradeModal from "../components/UpgradeModal";
-import { splitSecret } from "@handoverkey/crypto";
+import {
+  splitSecret,
+  wrapShare,
+  generateSharePassphrase,
+} from "@handoverkey/crypto";
 import {
   exportRawMasterKey,
   arrayBufferToBase64,
@@ -46,7 +50,8 @@ const Successors: React.FC = () => {
   const [delay, setDelay] = useState(30);
   const [error, setError] = useState<string | null>(null);
   const [generatingShares, setGeneratingShares] = useState(false);
-  const [generatedShares, setGeneratedShares] = useState<
+  // Maps successor id -> the out-of-band passphrase the owner must deliver.
+  const [generatedPassphrases, setGeneratedPassphrases] = useState<
     Record<string, string>
   >({});
   const [shareThreshold, setShareThreshold] = useState<number | null>(null);
@@ -156,23 +161,28 @@ const Successors: React.FC = () => {
         : Math.min(2, successors.length);
 
       const shares = splitSecret(rawMasterKey, successors.length, threshold);
-      const sharePayload = successors.map((successor, index) => ({
-        id: successor.id,
-        encryptedShare: arrayBufferToBase64(shares[index]),
-      }));
+
+      // Zero-knowledge custody: each share is wrapped (encrypted) with a unique
+      // per-successor passphrase BEFORE it ever leaves this browser. The server
+      // only ever receives the wrapped (unreadable) envelope -- never the
+      // passphrase -- so it can never reconstruct the master key.
+      const passphrases: Record<string, string> = {};
+      const sharePayload = await Promise.all(
+        successors.map(async (successor, index) => {
+          const passphrase = generateSharePassphrase();
+          passphrases[successor.id] = passphrase;
+          const wrapped = await wrapShare(shares[index], passphrase);
+          return { id: successor.id, encryptedShare: wrapped };
+        }),
+      );
 
       await api.put("/successors/shares", { shares: sharePayload });
 
-      setGeneratedShares(
-        sharePayload.reduce<Record<string, string>>((acc, item) => {
-          acc[item.id] = item.encryptedShare;
-          return acc;
-        }, {}),
-      );
+      setGeneratedPassphrases(passphrases);
       setShareThreshold(threshold);
 
       success(
-        `Distributed ${successors.length} shares (threshold: ${threshold}). Share values are now stored securely for handover.`,
+        `Wrapped ${successors.length} shares (threshold: ${threshold}). Deliver each recovery passphrase to its successor through a separate secure channel.`,
       );
       await fetchSuccessors();
     } catch (err) {
@@ -410,20 +420,31 @@ const Successors: React.FC = () => {
         )}
       </div>
 
-      {Object.keys(generatedShares).length > 0 && (
+      {Object.keys(generatedPassphrases).length > 0 && (
         <div className="mt-8 card p-6">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-            Generated Share Summary
+            Deliver Recovery Passphrases
           </h3>
-          <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-            Threshold: {shareThreshold} of {successors.length} shares required.
-            Store copies of these shares in secure channels for your successors.
-          </p>
+          <div className="mt-2 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-4">
+            <p className="text-sm text-amber-800 dark:text-amber-300">
+              Threshold: <strong>{shareThreshold}</strong> of{" "}
+              {successors.length} successors required to unlock your vault.
+            </p>
+            <p className="text-sm text-amber-800 dark:text-amber-300 mt-2">
+              Each successor&apos;s encrypted share is now stored, but it is
+              useless without the matching passphrase below. HandoverKey never
+              sees these passphrases. Give each one to its successor through a{" "}
+              <strong>separate, secure channel</strong> (in person, a sealed
+              letter, or a password manager). They are shown{" "}
+              <strong>once</strong> and cannot be recovered &mdash; if you lose
+              them, regenerate the shares.
+            </p>
+          </div>
 
           <div className="mt-4 space-y-3">
             {successors.map((successor) => {
-              const shareValue = generatedShares[successor.id];
-              if (!shareValue) {
+              const passphrase = generatedPassphrases[successor.id];
+              if (!passphrase) {
                 return null;
               }
 
@@ -435,9 +456,23 @@ const Successors: React.FC = () => {
                   <p className="text-sm font-medium text-gray-900 dark:text-white">
                     {successor.name} ({successor.email})
                   </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 break-all font-mono">
-                    {shareValue}
-                  </p>
+                  <div className="mt-2 flex items-center justify-between gap-3">
+                    <code className="text-sm text-gray-900 dark:text-gray-100 break-all font-mono tracking-wider">
+                      {passphrase}
+                    </code>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        navigator.clipboard
+                          ?.writeText(passphrase)
+                          .then(() => success("Passphrase copied"))
+                          .catch(() => showError("Failed to copy"));
+                      }}
+                      className="text-sm text-blue-600 hover:text-blue-700 font-medium whitespace-nowrap"
+                    >
+                      Copy
+                    </button>
+                  </div>
                 </div>
               );
             })}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -2,5 +2,6 @@ export * from "./types.js";
 export * from "./key-derivation.js";
 export * from "./encryption.js";
 export * from "./shamir.js";
+export * from "./share-custody.js";
 export * from "./utils.js";
 export * from "./errors.js";

--- a/packages/crypto/src/share-custody.test.ts
+++ b/packages/crypto/src/share-custody.test.ts
@@ -1,0 +1,107 @@
+import {
+  generateSharePassphrase,
+  wrapShare,
+  unwrapShare,
+  isWrappedShare,
+} from "./share-custody.js";
+import { splitSecret, reconstructSecret } from "./shamir.js";
+import { ValidationError, DecryptionError } from "./errors.js";
+
+describe("share custody", () => {
+  describe("generateSharePassphrase", () => {
+    it("generates a grouped passphrase with the default entropy", () => {
+      const passphrase = generateSharePassphrase();
+      // 4 groups of 5 chars + 3 separators = 23 chars
+      expect(passphrase).toMatch(/^[A-Z2-9]{5}(-[A-Z2-9]{5}){3}$/);
+    });
+
+    it("supports a custom number of groups", () => {
+      const passphrase = generateSharePassphrase(6);
+      expect(passphrase.split("-")).toHaveLength(6);
+    });
+
+    it("produces unique passphrases", () => {
+      const values = new Set(
+        Array.from({ length: 50 }, () => generateSharePassphrase()),
+      );
+      expect(values.size).toBe(50);
+    });
+
+    it("rejects fewer than 2 groups", () => {
+      expect(() => generateSharePassphrase(1)).toThrow(ValidationError);
+    });
+  });
+
+  describe("wrapShare / unwrapShare", () => {
+    it("round-trips an arbitrary binary share", async () => {
+      const share = crypto.getRandomValues(new Uint8Array(34));
+      const passphrase = generateSharePassphrase();
+
+      const wrapped = await wrapShare(share, passphrase);
+      expect(isWrappedShare(wrapped)).toBe(true);
+
+      const unwrapped = await unwrapShare(wrapped, passphrase);
+      expect(Array.from(unwrapped)).toEqual(Array.from(share));
+    });
+
+    it("produces different envelopes for the same input (random salt/iv)", async () => {
+      const share = crypto.getRandomValues(new Uint8Array(34));
+      const passphrase = generateSharePassphrase();
+      const a = await wrapShare(share, passphrase);
+      const b = await wrapShare(share, passphrase);
+      expect(a).not.toEqual(b);
+    });
+
+    it("fails to unwrap with the wrong passphrase", async () => {
+      const share = crypto.getRandomValues(new Uint8Array(34));
+      const wrapped = await wrapShare(share, generateSharePassphrase());
+      await expect(
+        unwrapShare(wrapped, generateSharePassphrase()),
+      ).rejects.toThrow(DecryptionError);
+    });
+
+    it("rejects an empty share", async () => {
+      await expect(
+        wrapShare(new Uint8Array(0), "longenoughpass"),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("rejects a short passphrase", async () => {
+      const share = crypto.getRandomValues(new Uint8Array(34));
+      await expect(wrapShare(share, "short")).rejects.toThrow(ValidationError);
+    });
+
+    it("rejects malformed envelopes", async () => {
+      await expect(unwrapShare("not-an-envelope", "pass")).rejects.toThrow(
+        ValidationError,
+      );
+      await expect(unwrapShare("", "pass")).rejects.toThrow(ValidationError);
+    });
+
+    it("supports full Shamir split -> wrap -> unwrap -> reconstruct", async () => {
+      const secret = crypto.getRandomValues(new Uint8Array(32));
+      const shares = splitSecret(secret, 3, 2);
+      const passphrases = shares.map(() => generateSharePassphrase());
+
+      const wrapped = await Promise.all(
+        shares.map((share, i) => wrapShare(share, passphrases[i])),
+      );
+
+      // Two successors unwrap their shares out-of-band and reconstruct.
+      const recoveredA = await unwrapShare(wrapped[0], passphrases[0]);
+      const recoveredB = await unwrapShare(wrapped[2], passphrases[2]);
+
+      const reconstructed = reconstructSecret([recoveredA, recoveredB], 2);
+      expect(Array.from(reconstructed)).toEqual(Array.from(secret));
+    });
+  });
+
+  describe("isWrappedShare", () => {
+    it("returns false for non-envelope values", () => {
+      expect(isWrappedShare(null)).toBe(false);
+      expect(isWrappedShare(undefined)).toBe(false);
+      expect(isWrappedShare("plain-base64-share")).toBe(false);
+      expect(isWrappedShare("hkshare.v2.a.b.c")).toBe(false);
+    });
+  });
+});

--- a/packages/crypto/src/share-custody.ts
+++ b/packages/crypto/src/share-custody.ts
@@ -1,0 +1,156 @@
+import { deriveKey } from "./key-derivation.js";
+import { encrypt, decrypt } from "./encryption.js";
+import { generateSalt, toBase64, fromBase64 } from "./utils.js";
+import { ValidationError } from "./errors.js";
+
+/**
+ * Zero-knowledge share custody.
+ *
+ * A Shamir key share is wrapped (encrypted) client-side with a per-successor
+ * passphrase BEFORE it is ever sent to the server. The server therefore only
+ * ever stores opaque ciphertext envelopes and never the passphrases, so it can
+ * never reconstruct the master key even if it holds every wrapped share.
+ *
+ * The owner delivers each passphrase to the corresponding successor through an
+ * out-of-band channel (in person, sealed letter, password manager link, etc.).
+ */
+
+const ENVELOPE_PREFIX = "hkshare";
+const ENVELOPE_VERSION = "v1";
+const WRAP_ITERATIONS = 210000;
+const PASSPHRASE_MIN_LENGTH = 8;
+
+// Avoid ambiguous characters (0/O, 1/I/l) so passphrases are easy to transcribe.
+const PASSPHRASE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+/**
+ * Generates a human-friendly, high-entropy passphrase that the owner shares
+ * with a successor out-of-band. Format: `XXXXX-XXXXX-XXXXX-XXXXX`.
+ *
+ * @param groups - Number of 5-character groups (default 4 => ~98 bits).
+ */
+export function generateSharePassphrase(groups: number = 4): string {
+  if (!Number.isInteger(groups) || groups < 2) {
+    throw new ValidationError("Passphrase must have at least 2 groups");
+  }
+
+  const charCount = groups * 5;
+  const randomBytes = crypto.getRandomValues(new Uint8Array(charCount));
+  const chars: string[] = [];
+
+  for (let i = 0; i < charCount; i++) {
+    chars.push(
+      PASSPHRASE_ALPHABET[randomBytes[i] % PASSPHRASE_ALPHABET.length],
+    );
+    if ((i + 1) % 5 === 0 && i + 1 < charCount) {
+      chars.push("-");
+    }
+  }
+
+  return chars.join("");
+}
+
+/**
+ * Wraps (encrypts) a Shamir share with a passphrase. The returned string is a
+ * self-describing envelope safe to store server-side.
+ *
+ * The raw share is base64-encoded before encryption so that arbitrary binary
+ * bytes survive the encrypt/decrypt (UTF-8 string) round trip intact.
+ *
+ * @param share - The raw Shamir share bytes.
+ * @param passphrase - The out-of-band passphrase known only to owner + successor.
+ * @returns Envelope string: `hkshare.v1.<saltB64>.<ivB64>.<ciphertextB64>`.
+ */
+export async function wrapShare(
+  share: Uint8Array,
+  passphrase: string,
+): Promise<string> {
+  if (!(share instanceof Uint8Array) || share.length === 0) {
+    throw new ValidationError("Share must be a non-empty Uint8Array");
+  }
+
+  if (
+    typeof passphrase !== "string" ||
+    passphrase.length < PASSPHRASE_MIN_LENGTH
+  ) {
+    throw new ValidationError(
+      `Passphrase must be at least ${PASSPHRASE_MIN_LENGTH} characters`,
+    );
+  }
+
+  const salt = generateSalt(16);
+  const key = await deriveKey(passphrase, salt, {
+    iterations: WRAP_ITERATIONS,
+  });
+  const encrypted = await encrypt(toBase64(share), key, { ivLength: 12 });
+
+  return [
+    ENVELOPE_PREFIX,
+    ENVELOPE_VERSION,
+    toBase64(salt),
+    toBase64(encrypted.iv),
+    toBase64(encrypted.data),
+  ].join(".");
+}
+
+/**
+ * Unwraps (decrypts) a wrapped share envelope using the passphrase.
+ *
+ * @param wrapped - Envelope produced by {@link wrapShare}.
+ * @param passphrase - The out-of-band passphrase.
+ * @returns The raw Shamir share bytes.
+ * @throws {DecryptionError} If the passphrase is wrong or data is tampered.
+ */
+export async function unwrapShare(
+  wrapped: string,
+  passphrase: string,
+): Promise<Uint8Array> {
+  if (typeof wrapped !== "string" || wrapped.length === 0) {
+    throw new ValidationError("Wrapped share must be a non-empty string");
+  }
+
+  if (typeof passphrase !== "string" || passphrase.length === 0) {
+    throw new ValidationError("Passphrase must be provided");
+  }
+
+  const parts = wrapped.split(".");
+  if (
+    parts.length !== 5 ||
+    parts[0] !== ENVELOPE_PREFIX ||
+    parts[1] !== ENVELOPE_VERSION
+  ) {
+    throw new ValidationError(
+      "Unsupported or malformed wrapped share envelope",
+    );
+  }
+
+  const salt = fromBase64(parts[2]);
+  const iv = fromBase64(parts[3]);
+  const ciphertext = fromBase64(parts[4]);
+
+  const key = await deriveKey(passphrase, salt, {
+    iterations: WRAP_ITERATIONS,
+  });
+
+  const shareBase64 = await decrypt(
+    { data: ciphertext, iv, algorithm: "AES-256-GCM" },
+    key,
+  );
+
+  return fromBase64(shareBase64);
+}
+
+/**
+ * Returns true if the given string looks like a wrapped share envelope.
+ */
+export function isWrappedShare(value: string | null | undefined): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const parts = value.split(".");
+  return (
+    parts.length === 5 &&
+    parts[0] === ENVELOPE_PREFIX &&
+    parts[1] === ENVELOPE_VERSION
+  );
+}

--- a/packages/crypto/src/share-custody.ts
+++ b/packages/crypto/src/share-custody.ts
@@ -35,15 +35,27 @@ export function generateSharePassphrase(groups: number = 4): string {
   }
 
   const charCount = groups * 5;
-  const randomBytes = crypto.getRandomValues(new Uint8Array(charCount));
+  const alphabetLength = PASSPHRASE_ALPHABET.length;
+  // Reject bytes in the final, incomplete cycle of the alphabet so that
+  // `byte % alphabetLength` is uniform (avoids modulo bias from a CSPRNG).
+  const unbiasedCeiling = Math.floor(256 / alphabetLength) * alphabetLength;
   const chars: string[] = [];
 
-  for (let i = 0; i < charCount; i++) {
-    chars.push(
-      PASSPHRASE_ALPHABET[randomBytes[i] % PASSPHRASE_ALPHABET.length],
+  let produced = 0;
+  while (produced < charCount) {
+    const randomBytes = crypto.getRandomValues(
+      new Uint8Array(charCount - produced),
     );
-    if ((i + 1) % 5 === 0 && i + 1 < charCount) {
-      chars.push("-");
+    for (let i = 0; i < randomBytes.length && produced < charCount; i++) {
+      const byte = randomBytes[i];
+      if (byte >= unbiasedCeiling) {
+        continue;
+      }
+      chars.push(PASSPHRASE_ALPHABET[byte % alphabetLength]);
+      produced++;
+      if (produced % 5 === 0 && produced < charCount) {
+        chars.push("-");
+      }
     }
   }
 

--- a/packages/database/src/repositories/handover-process-repository.ts
+++ b/packages/database/src/repositories/handover-process-repository.ts
@@ -51,7 +51,7 @@ export class HandoverProcessRepository {
         .selectFrom("handover_processes")
         .selectAll()
         .where("user_id", "=", userId)
-        .where("status", "not in", ["completed", "cancelled"])
+        .where("status", "not in", ["completed", "cancelled", "expired"])
         .orderBy("created_at", "desc")
         .limit(1)
         .executeTakeFirst();
@@ -60,6 +60,29 @@ export class HandoverProcessRepository {
     } catch (error) {
       throw new QueryError(
         `Failed to find active handover process: ${error instanceof Error ? error.message : "Unknown error"}`,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
+   * Returns the most recent handover process for a user regardless of status
+   * (including terminal states such as completed/expired/cancelled).
+   */
+  async findLatestByUserId(userId: string): Promise<HandoverProcess | null> {
+    try {
+      const process = await this.db
+        .selectFrom("handover_processes")
+        .selectAll()
+        .where("user_id", "=", userId)
+        .orderBy("created_at", "desc")
+        .limit(1)
+        .executeTakeFirst();
+
+      return process ?? null;
+    } catch (error) {
+      throw new QueryError(
+        `Failed to find latest handover process: ${error instanceof Error ? error.message : "Unknown error"}`,
         error instanceof Error ? error : undefined,
       );
     }

--- a/packages/database/src/repositories/successor-notification-repository.ts
+++ b/packages/database/src/repositories/successor-notification-repository.ts
@@ -77,6 +77,27 @@ export class SuccessorNotificationRepository {
     }
   }
 
+  async findBySuccessor(
+    handoverProcessId: string,
+    successorId: string,
+  ): Promise<SuccessorNotification | null> {
+    try {
+      const notification = await this.db
+        .selectFrom("successor_notifications")
+        .selectAll()
+        .where("handover_process_id", "=", handoverProcessId)
+        .where("successor_id", "=", successorId)
+        .executeTakeFirst();
+
+      return notification ?? null;
+    } catch (error) {
+      throw new QueryError(
+        `Failed to find successor notification: ${error instanceof Error ? error.message : "Unknown error"}`,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
   async findPendingVerifications(): Promise<SuccessorNotification[]> {
     try {
       const notifications = await this.db

--- a/packages/shared/src/types/dead-mans-switch.ts
+++ b/packages/shared/src/types/dead-mans-switch.ts
@@ -161,6 +161,9 @@ export enum HandoverProcessStatus {
   READY_FOR_TRANSFER = "ready_for_transfer",
   COMPLETED = "completed",
   CANCELLED = "cancelled",
+  // Terminal state when the response window closed without enough successors
+  // accepting (e.g. all declined). The vault is never released in this state.
+  EXPIRED = "expired",
 }
 
 export enum ReminderType {


### PR DESCRIPTION
## Summary

PR1 of the trust remediation series. Fixes the highest-priority security-correctness issues that made the product untrustworthy.

### Share custody is now zero-knowledge
- New `@handoverkey/crypto` `wrapShare` / `unwrapShare` / `generateSharePassphrase`: every Shamir share is encrypted **client-side** with a unique per-successor passphrase before it is ever sent to the server.
- The server now stores only opaque wrapped envelopes and **never** the passphrases — it can no longer reconstruct the master key even if it holds every share.
- `Successors.tsx` wraps shares before upload and shows the owner the out-of-band recovery passphrases (once) to deliver to each successor separately.
- Handover alert emails **no longer contain key shares**; they only link to the successor portal. The portal returns the successor's wrapped share for local passphrase unwrap.
- `SuccessorAccess.tsx` gains an accept step and a recovery-passphrase field that unwraps the share locally.

### Dead-man's-switch actually runs for new users
- `UserService.createUser` now creates a default `inactivity_settings` row, so the inactivity monitor enrolls every new user.
- `successor_notifications` rows are created in the real grace-period path (`processGracePeriodExpiration`), not just in tests, so accept/decline + completion work in production.

### Access gating + K-of-N enforcement
- Successor vault access requires the successor to have **ACCEPTED** (verified) **and** the K-of-N acceptance threshold to be met — enforced server-side in `HandoverOrchestrator.getSuccessorAccessDecision`.
- Completion semantics fixed: reaching the threshold COMPLETES (releases) the handover; all/insufficient declines move it to the new terminal `EXPIRED` status **without** releasing the vault.

## Test plan
- [x] `npm run build` — green
- [x] `npm run lint` — green
- [x] `npm test` — green (crypto 91, api 112, database 20, shared 14, web)
- [x] New crypto tests: wrap/unwrap round-trip, wrong-passphrase failure, full split→wrap→unwrap→reconstruct
- [x] Updated handover integration tests: deny-until-accept, K-of-N completion, EXPIRED on insufficient acceptances, default inactivity settings on registration

## Notes for reviewers
- Co-successor share exchange in the portal still uses pasted Base64 (full guided peer-exchange UX is deferred to PR4).
- 1-of-1 free-tier handover contradiction is intentionally left for PR5.