### PR TITLE
feat: trust UX & accessibility

### DIFF
--- a/apps/api/src/__tests__/integration/auth-full.test.ts
+++ b/apps/api/src/__tests__/integration/auth-full.test.ts
@@ -197,6 +197,9 @@ describe("Auth Full Flow Integration", () => {
       .post("/api/v1/auth/login")
       .send({ email, password });
     expect(loginWithout2fa.status).toBe(401);
+    // The client relies on this flag to reveal the 2FA input instead of
+    // treating the 401 as a credential failure.
+    expect(loginWithout2fa.body.twoFactorRequired).toBe(true);
 
     const loginWith2fa = await request(app)
       .post("/api/v1/auth/login")

--- a/apps/api/src/controllers/auth-controller.ts
+++ b/apps/api/src/controllers/auth-controller.ts
@@ -140,6 +140,17 @@ export class AuthController {
 
       // Secure 2FA check
       if (user.twoFactorEnabled === true) {
+        // Password was correct but no second factor was supplied yet. Signal
+        // the client to reveal the 2FA field WITHOUT recording a failed login
+        // attempt (the user has not actually failed authentication).
+        if (!twoFactorCode && !recoveryCode) {
+          res.status(401).json({
+            error: "Two-factor authentication required",
+            twoFactorRequired: true,
+          });
+          return;
+        }
+
         await UserService.verifyTwoFactorChallenge({
           userId: user.id,
           twoFactorSecret: user.twoFactorSecret,

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -4,10 +4,12 @@ import {
   ShieldCheckIcon,
   UserGroupIcon,
   ClockIcon,
+  ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import api from "../services/api";
 import { Link } from "react-router-dom";
 import { useToast } from "../contexts/ToastContext";
+import { getApiErrorMessage } from "../services/api-error";
 import OnboardingChecklist, {
   type SetupStatus,
 } from "../components/OnboardingChecklist";
@@ -18,6 +20,21 @@ interface ActivityLog {
   activity_type: string;
   created_at: string;
   ip_address?: string;
+}
+
+interface SafetyStatus {
+  lastActivity: string | null;
+  thresholdDays: number;
+  isPaused: boolean;
+  pausedUntil: string | null;
+  daysUntilHandover: number | null;
+}
+
+interface HandoverStatus {
+  active: boolean;
+  id?: string;
+  status?: string;
+  gracePeriodEnds?: string;
 }
 
 const Dashboard: React.FC = () => {
@@ -46,7 +63,10 @@ const Dashboard: React.FC = () => {
   const [activities, setActivities] = useState<ActivityLog[]>([]);
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
+  const [cancellingHandover, setCancellingHandover] = useState(false);
   const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null);
+  const [safety, setSafety] = useState<SafetyStatus | null>(null);
+  const [handover, setHandover] = useState<HandoverStatus | null>(null);
   const [onboardingDismissed, setOnboardingDismissed] = useState(false);
 
   useEffect(() => {
@@ -61,7 +81,7 @@ const Dashboard: React.FC = () => {
 
   const fetchData = useCallback(async () => {
     try {
-      const [vaultRes, successorsRes, activityRes, inactivityRes] =
+      const [vaultRes, successorsRes, activityRes, inactivityRes, handoverRes] =
         await Promise.all([
           api.get("/vault/entries"),
           api.get("/successors"),
@@ -72,6 +92,7 @@ const Dashboard: React.FC = () => {
             if (status === 404) return null;
             throw err;
           }),
+          api.get("/handover/status").catch(() => null),
         ]);
 
       // Vault returns array directly
@@ -97,13 +118,51 @@ const Dashboard: React.FC = () => {
         hasInactivityConfig,
       });
 
-      // Calculate days active from user account creation date
-      const daysActive = user?.createdAt
+      // Activity returns { data: [...], pagination: {...} }
+      const activityList: ActivityLog[] = activityRes.data.data || [];
+      setActivities(activityList);
+
+      // Derive the dead-man's-switch safety status.
+      const thresholdDays = inactivitySettings?.thresholdDays ?? 90;
+      const lastActivity = activityList[0]?.created_at ?? null;
+      const daysSinceActivity = lastActivity
         ? Math.floor(
-            (new Date().getTime() - new Date(user.createdAt).getTime()) /
+            (Date.now() - new Date(lastActivity).getTime()) /
               (1000 * 3600 * 24),
           )
-        : 0;
+        : null;
+      const daysUntilHandover =
+        daysSinceActivity === null
+          ? null
+          : Math.max(0, thresholdDays - daysSinceActivity);
+
+      setSafety({
+        lastActivity,
+        thresholdDays,
+        isPaused: Boolean(inactivitySettings?.isPaused),
+        pausedUntil: inactivitySettings?.pausedUntil ?? null,
+        daysUntilHandover,
+      });
+
+      const handoverData = handoverRes?.data;
+      setHandover(
+        handoverData?.active
+          ? {
+              active: true,
+              id: handoverData.handover?.id,
+              status: handoverData.handover?.status,
+              gracePeriodEnds: handoverData.handover?.gracePeriodEnds,
+            }
+          : { active: false },
+      );
+
+      // "Days until handover" is the trust-relevant number, not a vanity
+      // "days since signup" stat.
+      const daysUntilStat = inactivitySettings?.isPaused
+        ? "Paused"
+        : daysUntilHandover === null
+          ? "—"
+          : daysUntilHandover.toString();
 
       setStats([
         {
@@ -119,21 +178,18 @@ const Dashboard: React.FC = () => {
           color: "bg-green-500",
         },
         {
-          name: "Days Active",
-          stat: daysActive.toString(),
+          name: "Days Until Handover",
+          stat: daysUntilStat,
           icon: ClockIcon,
           color: "bg-purple-500",
         },
       ]);
-
-      // Activity returns { data: [...], pagination: {...} }
-      setActivities(activityRes.data.data || []);
-    } catch {
-      // Ignore error
+    } catch (err) {
+      showError(getApiErrorMessage(err, "Failed to load your dashboard"));
     } finally {
       setLoading(false);
     }
-  }, [user?.createdAt]);
+  }, [showError]);
 
   useEffect(() => {
     if (user) {
@@ -147,11 +203,31 @@ const Dashboard: React.FC = () => {
       await api.post("/activity/check-in", {});
       success("Check-in recorded. Inactivity timer reset.");
       await fetchData();
-    } catch {
-      showError("Failed to record check-in");
+    } catch (err) {
+      showError(getApiErrorMessage(err, "Failed to record check-in"));
     } finally {
       setCheckingIn(false);
     }
+  };
+
+  const handleCancelHandover = async () => {
+    setCancellingHandover(true);
+    try {
+      await api.post("/handover/cancel", {
+        reason: "Cancelled from dashboard",
+      });
+      success("Handover cancelled. Your vault remains private.");
+      await fetchData();
+    } catch (err) {
+      showError(getApiErrorMessage(err, "Failed to cancel handover"));
+    } finally {
+      setCancellingHandover(false);
+    }
+  };
+
+  const formatExactDate = (value: string | null) => {
+    if (!value) return "No activity recorded yet";
+    return new Date(value).toLocaleString();
   };
 
   const formatDate = (dateString: string) => {
@@ -205,6 +281,80 @@ const Dashboard: React.FC = () => {
               localStorage.setItem("onboarding_dismissed", "true");
             }}
           />
+        </div>
+      )}
+
+      {!loading && handover?.active && (
+        <div className="mt-8 rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-5">
+          <div className="flex items-start gap-3">
+            <ExclamationTriangleIcon
+              className="h-6 w-6 flex-shrink-0 text-red-600 dark:text-red-400"
+              aria-hidden="true"
+            />
+            <div className="flex-1">
+              <h3 className="text-base font-semibold text-red-800 dark:text-red-300">
+                {handover.status === "grace_period"
+                  ? "Handover grace period in progress"
+                  : "Handover in progress"}
+              </h3>
+              <p className="mt-1 text-sm text-red-700 dark:text-red-300">
+                Your dead-man&apos;s switch has triggered because no activity
+                was detected.
+                {handover.gracePeriodEnds &&
+                  ` Successors will be notified after ${new Date(
+                    handover.gracePeriodEnds,
+                  ).toLocaleString()}.`}{" "}
+                If this is a mistake, cancel it now to keep your vault private.
+              </p>
+              <button
+                onClick={handleCancelHandover}
+                disabled={cancellingHandover}
+                className="mt-3 btn btn-primary"
+              >
+                {cancellingHandover ? "Cancelling..." : "Cancel handover"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!loading && safety && (
+        <div className="mt-8">
+          <h3 className="text-base font-semibold leading-6 text-gray-900 dark:text-white">
+            Safety Status
+          </h3>
+          <div className="mt-4 card p-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Last check-in
+              </p>
+              <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                {formatExactDate(safety.lastActivity)}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {safety.isPaused ? "Switch status" : "Days until handover"}
+              </p>
+              <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                {safety.isPaused
+                  ? safety.pausedUntil
+                    ? `Paused until ${new Date(safety.pausedUntil).toLocaleDateString()}`
+                    : "Paused"
+                  : safety.daysUntilHandover === null
+                    ? "—"
+                    : `${safety.daysUntilHandover} of ${safety.thresholdDays} days`}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Inactivity threshold
+              </p>
+              <p className="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                {safety.thresholdDays} days
+              </p>
+            </div>
+          </div>
         </div>
       )}
 

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -67,6 +67,8 @@ const Dashboard: React.FC = () => {
   const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null);
   const [safety, setSafety] = useState<SafetyStatus | null>(null);
   const [handover, setHandover] = useState<HandoverStatus | null>(null);
+  const [handoverStatusUnavailable, setHandoverStatusUnavailable] =
+    useState(false);
   const [onboardingDismissed, setOnboardingDismissed] = useState(false);
 
   useEffect(() => {
@@ -80,6 +82,10 @@ const Dashboard: React.FC = () => {
   }, []);
 
   const fetchData = useCallback(async () => {
+    // Track handover-status failures separately: silently assuming "no
+    // handover" could hide a genuinely active handover from the user, so we
+    // surface the uncertainty instead of dropping the red banner.
+    let handoverStatusFailed = false;
     try {
       const [vaultRes, successorsRes, activityRes, inactivityRes, handoverRes] =
         await Promise.all([
@@ -92,7 +98,10 @@ const Dashboard: React.FC = () => {
             if (status === 404) return null;
             throw err;
           }),
-          api.get("/handover/status").catch(() => null),
+          api.get("/handover/status").catch(() => {
+            handoverStatusFailed = true;
+            return null;
+          }),
         ]);
 
       // Vault returns array directly
@@ -145,6 +154,7 @@ const Dashboard: React.FC = () => {
       });
 
       const handoverData = handoverRes?.data;
+      setHandoverStatusUnavailable(handoverStatusFailed);
       setHandover(
         handoverData?.active
           ? {
@@ -284,6 +294,37 @@ const Dashboard: React.FC = () => {
         </div>
       )}
 
+      {!loading && handoverStatusUnavailable && (
+        <div
+          role="alert"
+          className="mt-8 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-5"
+        >
+          <div className="flex items-start gap-3">
+            <ExclamationTriangleIcon
+              className="h-6 w-6 flex-shrink-0 text-amber-600 dark:text-amber-400"
+              aria-hidden="true"
+            />
+            <div className="flex-1">
+              <h3 className="text-base font-semibold text-amber-800 dark:text-amber-300">
+                Handover status unavailable
+              </h3>
+              <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+                We couldn&apos;t check whether a handover is currently in
+                progress. If you were expecting a notice here, refresh the page
+                to try again.
+              </p>
+              <button
+                onClick={fetchData}
+                className="mt-3 btn btn-secondary"
+                type="button"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {!loading && handover?.active && (
         <div className="mt-8 rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-5">
           <div className="flex items-start gap-3">
@@ -293,7 +334,7 @@ const Dashboard: React.FC = () => {
             />
             <div className="flex-1">
               <h3 className="text-base font-semibold text-red-800 dark:text-red-300">
-                {handover.status === "grace_period"
+                {handover.status?.toUpperCase() === "GRACE_PERIOD"
                   ? "Handover grace period in progress"
                   : "Handover in progress"}
               </h3>

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -749,11 +749,17 @@ function ConflictCard({
 
 function FAQItem({ question, answer }: { question: string; answer: string }) {
   const [isOpen, setIsOpen] = useState(false);
+  const answerId = `faq-answer-${question
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")}`;
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 overflow-hidden">
       <button
         onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-controls={answerId}
         className="w-full flex items-center justify-between p-6 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
       >
         <span className="text-lg font-semibold text-gray-900 dark:text-white pr-4">
@@ -770,6 +776,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
       <AnimatePresence initial={false}>
         {isOpen && (
           <motion.div
+            id={answerId}
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import axios from "axios";
 import { useAuth } from "../contexts/AuthContext";
 import api from "../services/api";
 import { setMasterKey, deriveAuthKey } from "../services/encryption";
@@ -15,13 +16,24 @@ const Login: React.FC = () => {
   const [useRecoveryCode, setUseRecoveryCode] = useState(false);
   const [show2FA, setShow2FA] = useState(false);
   const [error, setError] = useState("");
+  const [info, setInfo] = useState("");
   const [loading, setLoading] = useState(false);
+  const twoFactorInputRef = useRef<HTMLInputElement>(null);
   const { login } = useAuth();
   const navigate = useNavigate();
+
+  // When the 2FA field is revealed, move focus to it so the user can type the
+  // code immediately without hunting for the input.
+  useEffect(() => {
+    if (show2FA && !useRecoveryCode) {
+      twoFactorInputRef.current?.focus();
+    }
+  }, [show2FA, useRecoveryCode]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setInfo("");
     setLoading(true);
     try {
       // 1. Derive Auth Key (Client-side Hashing)
@@ -51,6 +63,18 @@ const Login: React.FC = () => {
       login(userData);
       navigate("/dashboard");
     } catch (err: unknown) {
+      // If the server says a second factor is required, reveal the 2FA field
+      // and keep the entered credentials so the user can finish signing in.
+      if (
+        axios.isAxiosError(err) &&
+        err.response?.status === 401 &&
+        err.response.data?.twoFactorRequired
+      ) {
+        setShow2FA(true);
+        setError("");
+        setInfo("Enter your two-factor code to finish signing in.");
+        return;
+      }
       setError(getApiErrorMessage(err, "Failed to login"));
     } finally {
       setLoading(false);
@@ -101,6 +125,15 @@ const Login: React.FC = () => {
             {error && (
               <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
                 {error}
+              </div>
+            )}
+
+            {info && (
+              <div
+                role="status"
+                className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-300 px-4 py-3 rounded-lg text-sm"
+              >
+                {info}
               </div>
             )}
 
@@ -181,6 +214,7 @@ const Login: React.FC = () => {
                     </label>
                     <input
                       id="two-factor-code"
+                      ref={twoFactorInputRef}
                       type="text"
                       inputMode="numeric"
                       pattern="[0-9]{6}"

--- a/apps/web/src/pages/Sessions.tsx
+++ b/apps/web/src/pages/Sessions.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import api from "../services/api";
 import { useToast } from "../contexts/ToastContext";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 interface SessionItem {
   id: string;
@@ -18,6 +19,8 @@ const Sessions: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [invalidatingOthers, setInvalidatingOthers] = useState(false);
+  const [sessionToRevoke, setSessionToRevoke] = useState<string | null>(null);
+  const [confirmRevokeOthers, setConfirmRevokeOthers] = useState(false);
 
   const fetchSessions = async () => {
     try {
@@ -73,7 +76,7 @@ const Sessions: React.FC = () => {
         </div>
         <div className="mt-4 md:mt-0">
           <button
-            onClick={handleInvalidateOthers}
+            onClick={() => setConfirmRevokeOthers(true)}
             disabled={invalidatingOthers}
             className="btn btn-primary"
           >
@@ -116,7 +119,7 @@ const Sessions: React.FC = () => {
                   </span>
                 ) : (
                   <button
-                    onClick={() => handleInvalidateSession(session.id)}
+                    onClick={() => setSessionToRevoke(session.id)}
                     disabled={busyId === session.id}
                     className="text-sm text-red-600 hover:text-red-700 font-medium"
                   >
@@ -128,6 +131,35 @@ const Sessions: React.FC = () => {
           </ul>
         )}
       </div>
+
+      <ConfirmationModal
+        isOpen={sessionToRevoke !== null}
+        onClose={() => setSessionToRevoke(null)}
+        onConfirm={async () => {
+          const id = sessionToRevoke;
+          setSessionToRevoke(null);
+          if (id) {
+            await handleInvalidateSession(id);
+          }
+        }}
+        title="Revoke this session?"
+        message="This device will be signed out and will need to log in again. Continue?"
+        confirmText="Revoke session"
+        type="danger"
+      />
+
+      <ConfirmationModal
+        isOpen={confirmRevokeOthers}
+        onClose={() => setConfirmRevokeOthers(false)}
+        onConfirm={async () => {
+          setConfirmRevokeOthers(false);
+          await handleInvalidateOthers();
+        }}
+        title="Revoke all other sessions?"
+        message="Every other device signed into your account will be signed out immediately. This session stays active. Continue?"
+        confirmText="Revoke others"
+        type="danger"
+      />
     </div>
   );
 };

--- a/apps/web/src/pages/Successors.tsx
+++ b/apps/web/src/pages/Successors.tsx
@@ -666,6 +666,7 @@ const Successors: React.FC = () => {
                         </div>
                         <input
                           type="checkbox"
+                          aria-label={`Assign entry ${entry.name}`}
                           checked={selectedEntryIds.includes(entry.id)}
                           onChange={() => toggleEntrySelection(entry.id)}
                         />

--- a/apps/web/src/pages/Vault.tsx
+++ b/apps/web/src/pages/Vault.tsx
@@ -40,6 +40,11 @@ const Vault: React.FC = () => {
   const [selectedEntry, setSelectedEntry] = useState<VaultEntry | null>(null);
   const [exporting, setExporting] = useState(false);
   const [importing, setImporting] = useState(false);
+  // Holds a parsed "replace" import awaiting explicit confirmation, since it
+  // wipes the existing vault before importing.
+  const [pendingReplaceImport, setPendingReplaceImport] = useState<
+    unknown[] | null
+  >(null);
   const [upgradeModal, setUpgradeModal] = useState<{
     open: boolean;
     tier: string;
@@ -101,6 +106,7 @@ const Vault: React.FC = () => {
       setEntries(decryptedEntries);
     } catch (error) {
       console.error("Failed to fetch vault entries", error);
+      showError("Failed to load your vault. Please refresh and try again.");
     } finally {
       setLoading(false);
     }
@@ -228,13 +234,15 @@ const Vault: React.FC = () => {
         throw new Error("Invalid import file format");
       }
 
-      await api.post("/vault/import", {
-        mode:
-          !Array.isArray(parsed) && parsed.mode === "replace"
-            ? "replace"
-            : "merge",
-        entries,
-      });
+      const isReplace = !Array.isArray(parsed) && parsed.mode === "replace";
+
+      if (isReplace) {
+        // Don't destroy the existing vault without explicit confirmation.
+        setPendingReplaceImport(entries);
+        return;
+      }
+
+      await api.post("/vault/import", { mode: "merge", entries });
 
       success("Vault import completed");
       await fetchEntries();
@@ -243,6 +251,26 @@ const Vault: React.FC = () => {
     } finally {
       setImporting(false);
       event.target.value = "";
+    }
+  };
+
+  const confirmReplaceImport = async () => {
+    if (!pendingReplaceImport) {
+      return;
+    }
+    setImporting(true);
+    try {
+      await api.post("/vault/import", {
+        mode: "replace",
+        entries: pendingReplaceImport,
+      });
+      success("Vault replaced from import file");
+      await fetchEntries();
+    } catch {
+      showError("Failed to import vault file");
+    } finally {
+      setImporting(false);
+      setPendingReplaceImport(null);
     }
   };
 
@@ -348,8 +376,17 @@ const Vault: React.FC = () => {
             {filteredEntries.map((entry) => (
               <div
                 key={entry.id}
-                className="card p-6 hover:shadow-apple-lg transition-shadow cursor-pointer group"
+                role="button"
+                tabIndex={0}
+                aria-label={`Open secret ${entry.name || "Untitled Secret"}`}
+                className="card p-6 hover:shadow-apple-lg transition-shadow cursor-pointer group focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
                 onClick={() => handleEntryClick(entry)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleEntryClick(entry);
+                  }
+                }}
               >
                 <div className="flex items-center justify-between mb-4">
                   <span className="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-900/30 px-2 py-1 text-xs font-medium text-blue-700 dark:text-blue-300 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-500/20">
@@ -417,6 +454,16 @@ const Vault: React.FC = () => {
         accept="application/json"
         className="hidden"
         onChange={handleImportFile}
+      />
+
+      <ConfirmationModal
+        isOpen={pendingReplaceImport !== null}
+        onClose={() => setPendingReplaceImport(null)}
+        onConfirm={confirmReplaceImport}
+        title="Replace entire vault?"
+        message="This import is set to REPLACE mode. All of your current secrets will be permanently deleted and replaced with the contents of this file. This cannot be undone."
+        confirmText="Replace vault"
+        type="danger"
       />
 
       <UpgradeModal

--- a/apps/web/src/pages/Vault.tsx
+++ b/apps/web/src/pages/Vault.tsx
@@ -258,11 +258,15 @@ const Vault: React.FC = () => {
     if (!pendingReplaceImport) {
       return;
     }
+    // Capture the entries and close the modal immediately so the confirm
+    // button can't be clicked repeatedly to fire duplicate replace requests.
+    const entries = pendingReplaceImport;
+    setPendingReplaceImport(null);
     setImporting(true);
     try {
       await api.post("/vault/import", {
         mode: "replace",
-        entries: pendingReplaceImport,
+        entries,
       });
       success("Vault replaced from import file");
       await fetchEntries();
@@ -270,7 +274,6 @@ const Vault: React.FC = () => {
       showError("Failed to import vault file");
     } finally {
       setImporting(false);
-      setPendingReplaceImport(null);
     }
   };
 


### PR DESCRIPTION
## Summary

PR4 of the trust remediation series. **Depends on PR1 (#258)** — it is stacked on `fix/critical-trust-breakers` and its base should be retargeted to `main` once PR1 merges.

### Trust UX
- **Dashboard "Safety Status" panel**: last check-in, days-until-handover, pause state, and inactivity threshold. The misleading "Days Active" stat is replaced with **"Days Until Handover"**.
- **Active-handover / grace-period banner** with a one-click **Cancel handover** action (uses existing `/handover/status` + `/handover/cancel`).
- **2FA login fix**: the server returns a distinguishable `twoFactorRequired` 401 (without recording a failed-login attempt) and the login page auto-reveals + focuses the 2FA field while preserving the entered credentials.
- Dashboard and Vault now surface load failures as **user-visible errors** instead of silent catches.

### Accessibility
- Vault entry cards are **keyboard-operable** (`role=button`, `tabindex`, Enter/Space, visible focus ring, accessible label).
- FAQ accordion buttons expose `aria-expanded` / `aria-controls`.
- Successor "assign entry" checkboxes have accessible labels.
- **Confirmation dialogs** for session revoke (single + "revoke others") and for destructive "replace" vault import.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` green (web 14, api 112, crypto 91, database 20, shared 14)

## Deferred / notes
- Full "unify all bespoke modals on Headless UI" refactor and the deeper dark-mode modal audit are deferred (high churn, low risk); the new confirmations use the existing Headless UI `ConfirmationModal`.
- The successor accept/decline + passphrase-unwrap flow ships in PR1; this PR builds the owner-facing trust surface around it.